### PR TITLE
"Lazy load" the dashboard

### DIFF
--- a/cmd/goatcounter/buffer_test.go
+++ b/cmd/goatcounter/buffer_test.go
@@ -52,7 +52,7 @@ func TestBuffer(t *testing.T) {
 	var backend string
 	{
 		i := zsync.NewAtomicInt(0)
-		handle := handlers.NewBackend(zdb.MustGetDB(ctx), nil, false, false, "", 10)
+		handle := handlers.NewBackend(zdb.MustGetDB(ctx), nil, false, false, "", 15)
 		goatcounter.Memstore.TestInit(zdb.MustGetDB(ctx))
 
 		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/goatcounter/saas.go
+++ b/cmd/goatcounter/saas.go
@@ -83,7 +83,7 @@ func cmdSaas(f zli.Flags, ready chan<- struct{}, stop chan struct{}) error {
 		hosts := map[string]http.Handler{
 			d:          zhttp.RedirectHost("//www." + domain),
 			"www." + d: handlers.NewWebsite(db, dev),
-			"*":        handlers.NewBackend(db, acmeh, dev, c.GoatcounterCom, c.DomainStatic, 10),
+			"*":        handlers.NewBackend(db, acmeh, dev, c.GoatcounterCom, c.DomainStatic, 15),
 		}
 		if dev {
 			hosts[znet.RemovePort(domainStatic)] = handlers.NewStatic(chi.NewRouter(), dev, true)

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/boombuler/barcode v1.0.1
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/google/uuid v1.3.0
+	github.com/gorilla/websocket v1.4.2
 	github.com/mattn/go-sqlite3 v1.14.9
 	github.com/monoculum/formam v3.5.5+incompatible
 	github.com/oschwald/geoip2-golang v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfC
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/lib/pq v1.10.4 h1:SO9z7FRPzA03QhHKJrH5BXA6HU1rS4V2nIVrrNC1iYk=
 github.com/lib/pq v1.10.4/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/monoculum/formam v3.5.5+incompatible h1:iPl5csfEN96G2N2mGu8V/ZB62XLf9ySTpC8KRH6qXec=

--- a/handlers/backend.go
+++ b/handlers/backend.go
@@ -148,6 +148,7 @@ func (h backend) Mount(r chi.Router, db zdb.DB, dev bool, domainStatic string, d
 		{
 			ap := a.With(loggedInOrPublic, addz18n())
 			ap.Get("/", zhttp.Wrap(h.dashboard))
+			ap.Get("/loader", zhttp.Wrap(h.loader))
 			ap.Get("/load-widget", zhttp.Wrap(h.loadWidget))
 		}
 		{

--- a/handlers/loader.go
+++ b/handlers/loader.go
@@ -1,0 +1,153 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"zgo.at/json"
+	"zgo.at/zlog"
+	"zgo.at/zstd/zint"
+)
+
+// On dashboard view we generate a unique ID we send to the frontend, and
+// register a new loader:
+//
+// 	loader.register(someUnqiueID)
+//
+// The frontend initiatsed a WS connection, and we create a new connection here
+// too:
+//
+// 	loader.connect(someUniqueID)
+//
+// When we want to send a message:
+//
+// 	loader.send(someUniqueID, msg)
+//
+// Because we want to start rendering the charts *before* we send out any data,
+// we can't use just the connection itself as an ID. We also can't use the
+// userID because a user can have two tabs open. So, we need a connection ID.
+type loaderT struct {
+	mu    *sync.Mutex
+	conns map[zint.Uint128]*loaderClient
+}
+
+type loaderClient struct {
+	sync.Mutex
+	conn *websocket.Conn
+}
+
+func (l *loaderT) register(id zint.Uint128) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.conns[id] = nil
+}
+func (l *loaderT) unregister(id zint.Uint128) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	delete(l.conns, id)
+}
+func (l *loaderT) connect(id zint.Uint128, c *websocket.Conn) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if check, ok := l.conns[id]; !ok || check != nil {
+		zlog.Errorf("loader.connect: already have a connection for %s", id)
+	}
+	c.SetCloseHandler(func(code int, text string) error {
+		l.unregister(id)
+		return nil
+	})
+	l.conns[id] = &loaderClient{conn: c}
+}
+
+func (l *loaderT) sendJSON(id zint.Uint128, data interface{}) {
+	c, ok := l.conns[id]
+	if !ok {
+		zlog.Errorf("loader.send: not registered: %s", id)
+		return
+	}
+	if c == nil {
+		for i := 0; i < 1000; i++ {
+			if c == nil {
+				time.Sleep(10 * time.Millisecond)
+				c = l.conns[id]
+				if c != nil {
+					break
+				}
+			}
+		}
+		if c == nil {
+			zlog.Errorf("loader.send: no connection yet: %s", id)
+			return
+		}
+	}
+
+	c.Lock()
+	defer c.Unlock()
+	w, err := c.conn.NextWriter(websocket.TextMessage)
+	if err != nil {
+		w.Close()
+		zlog.Errorf("loader.send: %s: NextWriter: %s", id, err)
+		return
+	}
+
+	j, err := json.Marshal(data)
+	if err != nil {
+		zlog.Errorf("loader.send: %s: %s", id, err)
+		return
+	}
+
+	_, err = w.Write(j)
+	w.Close()
+	if err != nil {
+		zlog.Errorf("loader.send: %s: Write: %s", id, err)
+		return
+	}
+}
+
+var loader = loaderT{
+	mu:    new(sync.Mutex),
+	conns: make(map[zint.Uint128]*loaderClient),
+}
+
+func (h backend) loader(w http.ResponseWriter, r *http.Request) error {
+	ids := r.URL.Query().Get("id")
+	if ids == "" {
+		return fmt.Errorf("no id parameter")
+	}
+	id, err := zint.ParseUint128(ids, 16)
+	if err != nil {
+		return fmt.Errorf("id parameter: %w", err)
+	}
+
+	u := websocket.Upgrader{
+		HandshakeTimeout:  10 * time.Second,
+		ReadBufferSize:    4096,
+		WriteBufferSize:   4096,
+		EnableCompression: true,
+	}
+	c, err := u.Upgrade(w, r, nil)
+	if err != nil {
+		return err
+	}
+
+	loader.connect(id, c)
+
+	// Read messages.
+	go func() {
+		defer zlog.Recover()
+		for {
+			t, m, err := c.ReadMessage()
+			if err != nil {
+				break
+			}
+			fmt.Println("websocket msg:", t, string(m))
+		}
+		c.Close()
+	}()
+
+	return nil
+}

--- a/helper.go
+++ b/helper.go
@@ -13,10 +13,12 @@ import (
 	"math"
 	"strconv"
 
+	"github.com/google/uuid"
 	"github.com/mattn/go-sqlite3"
 	"zgo.at/z18n"
 	"zgo.at/zdb"
 	"zgo.at/zstd/zcrypto"
+	"zgo.at/zstd/zint"
 	"zgo.at/zvalidate"
 )
 
@@ -124,6 +126,20 @@ func LoadBufferKey(ctx context.Context) ([]byte, error) {
 		return nil, fmt.Errorf("LoadBufferKey: %w", err)
 	}
 	return key, nil
+}
+
+// UUID created a new UUID v4.
+func UUID() zint.Uint128 {
+	u, err := uuid.NewRandom()
+	if err != nil {
+		panic(fmt.Sprintf("uuid.NewRandom: %s", err))
+	}
+	i, err := zint.NewUint128(u[:])
+	if err != nil {
+		panic(err)
+	}
+
+	return i
 }
 
 func splitIntStr(ident []string) ([]int64, []string) {

--- a/memstore.go
+++ b/memstore.go
@@ -16,7 +16,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
 	"zgo.at/json"
 	"zgo.at/zdb"
 	"zgo.at/zlog"
@@ -393,19 +392,7 @@ func (m *ms) SessionID() zint.Uint128 {
 		TestSeqSession[1]++
 		return TestSeqSession
 	}
-
-	u, err := uuid.NewRandom()
-	if err != nil {
-		// Only failure here is if reading random failed.
-		panic(fmt.Sprintf("Memstore.SessionID: uuid.NewRandom: %s", err))
-	}
-
-	i, err := zint.NewUint128(u[:])
-	if err != nil {
-		panic(fmt.Sprintf("Memstore.SessionID: %s", err))
-	}
-
-	return i
+	return UUID()
 }
 
 func (m *ms) session(ctx context.Context, siteID, pathID int64, userSessionID, ua, remoteAddr string) (zint.Uint128, zbool.Bool) {

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -13,7 +13,18 @@
 
 	// Set up all the dashboard widget contents (but not the header).
 	var dashboard_widgets = function() {
-		;[draw_all_charts, paginate_pages, load_refs, hchart_detail, ref_pages, bind_scale].forEach((f) => f.call())
+		;[draw_all_charts, paginate_pages, load_refs, hchart_detail, ref_pages, bind_scale, dashboard_loader].forEach((f) => f.call())
+	}
+
+	// Open websocket for the dashboard loader.
+	var dashboard_loader = function() {
+		let cid  = $('#js-connect-id').text(),
+			conn = new WebSocket('ws://' + document.location.host + '/loader?id=' + cid)
+		conn.onmessage = function(e) {
+			let msg = JSON.parse(e.data)
+			$(`#dash-widgets div[data-widget=${msg.id}]`).html(msg.html)
+			draw_all_charts()
+		}
 	}
 
 	// Get the Y-axis scale.
@@ -354,13 +365,16 @@
 
 	// Draw this chart
 	var draw_chart = function(c) {
-		var canvas  = $(c).find('canvas')[0]
-		if (canvas.dataset.done === 't')
+		let canvas = $(c).find('canvas')[0]
+		if (!canvas || canvas.dataset.done === 't')
 			return
 		canvas.dataset.done = 't'
 
-		var ctx     = canvas.getContext('2d', {alpha: false}),
-			stats   = JSON.parse(c.dataset.stats),
+		let stats = JSON.parse(c.dataset.stats)
+		if (!stats)
+			return
+
+		let ctx     = canvas.getContext('2d', {alpha: false}),
 			max     = Math.max(10, parseInt(c.dataset.max, 10)),
 			scale   = parseInt($(c).closest('.count-list-pages').attr('data-scale'), 0),
 			daily   = c.dataset.daily === 'true',

--- a/tpl/_dashboard_hchart.gohtml
+++ b/tpl/_dashboard_hchart.gohtml
@@ -1,11 +1,10 @@
-{{- $x := horizontal_chart .Context .Stats .TotalUniqueUTC (and (not .RowsOnly) .HasSubMenu) true -}}
+{{- $x := (t $.Context "dashboard/loading|Loading…") -}}
+{{- if $.Loaded -}}{{- $x = horizontal_chart .Context .Stats .TotalUniqueUTC (and (not .RowsOnly) .HasSubMenu) true -}}{{- end -}}
 {{- if .RowsOnly -}}
 	{{- $x -}}
 {{- else -}}
 	<div class="hchart" data-widget="{{.ID}}">
-		<h2>{{.Header}}{{if eq .ID 7}}<sup style="float: right; font-size: 1rem;">
-				{{t .Context "label/collected-since|Collected since 2 Dec 2021"}}
-			</sup>{{end}}</h2>
+		<h2>{{.Header}}</h2>
 		{{template "_dashboard_warn_collect.gohtml" (map "IsCollected" .IsCollected "Context" .Context)}}
 		{{if .Err}}
 			<em>{{t .Context "p/error|Error: %(error-message)" .Err}}</em>

--- a/tpl/_dashboard_pages_rows.gohtml
+++ b/tpl/_dashboard_pages_rows.gohtml
@@ -37,5 +37,11 @@
 		</td>
 	</tr>
 {{else}}
-	<tr><td colspan="3"><em>{{t $.Context "dashboard/nothing-to-display|Nothing to display"}}</em></td></tr>
+	<tr><td colspan="3"><em>
+		{{if $.Loaded}}
+			{{t $.Context "dashboard/nothing-to-display|Nothing to display"}}
+		{{else}}
+			{{t $.Context "dashboard/loading|Loading…"}}
+		{{end}}
+	</em></td></tr>
 {{- end}}

--- a/tpl/_dashboard_toprefs.gohtml
+++ b/tpl/_dashboard_toprefs.gohtml
@@ -1,4 +1,5 @@
-{{- $x := horizontal_chart .Context .Stats .TotalUnique (not .RowsOnly) true -}}
+{{- $x := (t $.Context "dashboard/loading|Loading…") -}}
+{{- if .Loaded -}}{{- $x = horizontal_chart .Context .Stats .TotalUnique (not .RowsOnly) true -}}{{- end -}}
 {{- if .RowsOnly -}}
 	{{- $x -}}
 {{- else -}}

--- a/tpl/_dashboard_totals.gohtml
+++ b/tpl/_dashboard_totals.gohtml
@@ -1,4 +1,4 @@
-<div class="totals">
+<div class="totals" data-widget="{{.ID}}">
 	<h2 class="full-width">{{t .Context "dashboard/totals/header|Totals"}}
 		{{if .NoEvents}}
 			<small>{{t .Context `dashboard/totals/num-visits|%(num-visits) visits; %(num-views) pageviews; excluding events`

--- a/tpl/_dashboard_totals_row.gohtml
+++ b/tpl/_dashboard_totals_row.gohtml
@@ -2,8 +2,12 @@
 	{{if .Align}}<td class="col-count"></td><td class="col-path hide-mobile"></td>{{end}}
 	<td>
 		<div class="chart chart-{{$.Style}}" data-max="{{.Max}}" data-stats="{{.Page.Stats | json}}" data-daily="{{.Daily}}">
-			<span class="chart-right"><small class="scale" title="Y-axis scale">{{nformat .Max $.User}}</small></span>
-			<canvas></canvas>
+			{{if .Loaded}}
+				<span class="chart-right"><small class="scale" title="Y-axis scale">{{nformat .Max $.User}}</small></span>
+				<canvas></canvas>
+			{{else}}
+				{{t $.Context "dashboard/loading|Loading…"}}
+			{{end}}
 		</div>
 	</td>
 </tr></tbody>

--- a/tpl/dashboard.gohtml
+++ b/tpl/dashboard.gohtml
@@ -131,6 +131,7 @@
 </form>
 <span class="hide js-total-unique">{{.TotalUnique}}</span>
 <span class="hide js-total-unique-utc">{{.TotalUniqueUTC}}</span>
+<span class="hide" id="js-connect-id">{{.ConnectID}}</span>
 
 {{template "_dashboard_widgets.gohtml" .}}
 

--- a/widgets/browsers.go
+++ b/widgets/browsers.go
@@ -13,10 +13,11 @@ import (
 )
 
 type Browsers struct {
-	id   int
-	err  error
-	html template.HTML
-	s    goatcounter.WidgetSettings
+	id     int
+	loaded bool
+	err    error
+	html   template.HTML
+	s      goatcounter.WidgetSettings
 
 	Limit  int
 	Detail string
@@ -32,6 +33,7 @@ func (w *Browsers) SetHTML(h template.HTML)             { w.html = h }
 func (w Browsers) HTML() template.HTML                  { return w.html }
 func (w *Browsers) SetErr(h error)                      { w.err = h }
 func (w Browsers) Err() error                           { return w.err }
+func (w Browsers) ID() int                              { return w.id }
 func (w Browsers) Settings() goatcounter.WidgetSettings { return w.s }
 
 func (w *Browsers) SetSettings(s goatcounter.WidgetSettings) {
@@ -50,6 +52,7 @@ func (w *Browsers) GetData(ctx context.Context, a Args) (more bool, err error) {
 	} else {
 		err = w.Stats.ListBrowsers(ctx, a.Rng, a.PathFilter, w.Limit, a.Offset)
 	}
+	w.loaded = true
 	return w.Stats.More, err
 }
 
@@ -59,13 +62,14 @@ func (w Browsers) RenderHTML(ctx context.Context, shared SharedData) (string, in
 		ID             int
 		RowsOnly       bool
 		HasSubMenu     bool
+		Loaded         bool
 		Err            error
 		IsCollected    bool
 		Header         string
 		TotalUniqueUTC int
 		Stats          goatcounter.HitStats
 		Detail         string
-	}{ctx, w.id, shared.RowsOnly, true, w.err, isCol(ctx, goatcounter.CollectUserAgent),
+	}{ctx, w.id, shared.RowsOnly, true, w.loaded, w.err, isCol(ctx, goatcounter.CollectUserAgent),
 		z18n.T(ctx, "header/browsers|Browsers"),
 		shared.TotalUniqueUTC, w.Stats, w.Detail}
 }

--- a/widgets/internal.go
+++ b/widgets/internal.go
@@ -12,9 +12,10 @@ import (
 )
 
 type Max struct {
-	err  error
-	html template.HTML
-	s    goatcounter.WidgetSettings
+	loaded bool
+	err    error
+	html   template.HTML
+	s      goatcounter.WidgetSettings
 
 	Max int
 }
@@ -26,20 +27,23 @@ func (w *Max) SetHTML(h template.HTML)                                     {}
 func (w Max) HTML() template.HTML                                          { return w.html }
 func (w *Max) SetErr(h error)                                              { w.err = h }
 func (w Max) Err() error                                                   { return w.err }
+func (w Max) ID() int                                                      { return 0 }
 func (w Max) Settings() goatcounter.WidgetSettings                         { return w.s }
 func (w *Max) SetSettings(s goatcounter.WidgetSettings)                    { w.s = s }
 func (w Max) RenderHTML(context.Context, SharedData) (string, interface{}) { return "", nil }
 func (w *Max) GetData(ctx context.Context, a Args) (more bool, err error) {
 	w.Max, err = goatcounter.GetMax(ctx, a.Rng, a.PathFilter, a.Daily)
+	w.loaded = true
 	return false, err
 }
 
 type TotalCount struct {
 	goatcounter.TotalCount
 
-	err  error
-	html template.HTML
-	s    goatcounter.WidgetSettings
+	loaded bool
+	err    error
+	html   template.HTML
+	s      goatcounter.WidgetSettings
 
 	NoEvents bool
 }
@@ -51,11 +55,13 @@ func (w *TotalCount) SetHTML(h template.HTML)                                   
 func (w TotalCount) HTML() template.HTML                                          { return w.html }
 func (w *TotalCount) SetErr(h error)                                              { w.err = h }
 func (w TotalCount) Err() error                                                   { return w.err }
+func (w TotalCount) ID() int                                                      { return 0 }
 func (w TotalCount) Settings() goatcounter.WidgetSettings                         { return w.s }
 func (w *TotalCount) SetSettings(s goatcounter.WidgetSettings)                    { w.s = s }
 func (w TotalCount) RenderHTML(context.Context, SharedData) (string, interface{}) { return "", nil }
 
 func (w *TotalCount) GetData(ctx context.Context, a Args) (more bool, err error) {
 	w.TotalCount, err = goatcounter.GetTotalCount(ctx, a.Rng, a.PathFilter, w.NoEvents)
+	w.loaded = true
 	return false, err
 }

--- a/widgets/languages.go
+++ b/widgets/languages.go
@@ -13,10 +13,11 @@ import (
 )
 
 type Languages struct {
-	id   int
-	err  error
-	html template.HTML
-	s    goatcounter.WidgetSettings
+	id     int
+	loaded bool
+	err    error
+	html   template.HTML
+	s      goatcounter.WidgetSettings
 
 	Limit int
 	Stats goatcounter.HitStats
@@ -31,6 +32,7 @@ func (w *Languages) SetHTML(h template.HTML)             { w.html = h }
 func (w Languages) HTML() template.HTML                  { return w.html }
 func (w *Languages) SetErr(h error)                      { w.err = h }
 func (w Languages) Err() error                           { return w.err }
+func (w Languages) ID() int                              { return w.id }
 func (w Languages) Settings() goatcounter.WidgetSettings { return w.s }
 
 func (w *Languages) SetSettings(s goatcounter.WidgetSettings) {
@@ -42,6 +44,7 @@ func (w *Languages) SetSettings(s goatcounter.WidgetSettings) {
 
 func (w *Languages) GetData(ctx context.Context, a Args) (more bool, err error) {
 	err = w.Stats.ListLanguages(ctx, a.Rng, a.PathFilter, w.Limit, a.Offset)
+	w.loaded = true
 	return w.Stats.More, err
 }
 
@@ -53,11 +56,12 @@ func (w Languages) RenderHTML(ctx context.Context, shared SharedData) (string, i
 		ID             int
 		RowsOnly       bool
 		HasSubMenu     bool
+		Loaded         bool
 		Err            error
 		IsCollected    bool
 		Header         string
 		TotalUniqueUTC int
 		Stats          goatcounter.HitStats
-	}{ctx, w.id, shared.RowsOnly, false, w.err, isCol(ctx, goatcounter.CollectLanguage),
+	}{ctx, w.id, shared.RowsOnly, false, w.loaded, w.err, isCol(ctx, goatcounter.CollectLanguage),
 		header, shared.TotalUniqueUTC, w.Stats}
 }

--- a/widgets/locations.go
+++ b/widgets/locations.go
@@ -13,10 +13,11 @@ import (
 )
 
 type Locations struct {
-	id   int
-	err  error
-	html template.HTML
-	s    goatcounter.WidgetSettings
+	id     int
+	loaded bool
+	err    error
+	html   template.HTML
+	s      goatcounter.WidgetSettings
 
 	Limit  int
 	Detail string
@@ -32,6 +33,7 @@ func (w *Locations) SetHTML(h template.HTML)             { w.html = h }
 func (w Locations) HTML() template.HTML                  { return w.html }
 func (w *Locations) SetErr(h error)                      { w.err = h }
 func (w Locations) Err() error                           { return w.err }
+func (w Locations) ID() int                              { return w.id }
 func (w Locations) Settings() goatcounter.WidgetSettings { return w.s }
 
 func (w *Locations) SetSettings(s goatcounter.WidgetSettings) {
@@ -50,6 +52,7 @@ func (w *Locations) GetData(ctx context.Context, a Args) (more bool, err error) 
 	} else {
 		err = w.Stats.ListLocations(ctx, a.Rng, a.PathFilter, w.Limit, a.Offset)
 	}
+	w.loaded = true
 	return w.Stats.More, err
 }
 
@@ -69,12 +72,13 @@ func (w Locations) RenderHTML(ctx context.Context, shared SharedData) (string, i
 		ID             int
 		RowsOnly       bool
 		HasSubMenu     bool
+		Loaded         bool
 		Err            error
 		IsCollected    bool
 		Header         string
 		TotalUniqueUTC int
 		Stats          goatcounter.HitStats
 		Detail         string
-	}{ctx, w.id, shared.RowsOnly, true, w.err, isCol(ctx, goatcounter.CollectLocation),
+	}{ctx, w.id, shared.RowsOnly, true, w.loaded, w.err, isCol(ctx, goatcounter.CollectLocation),
 		header, shared.TotalUniqueUTC, w.Stats, w.Detail}
 }

--- a/widgets/pages.go
+++ b/widgets/pages.go
@@ -17,10 +17,11 @@ import (
 )
 
 type Pages struct {
-	id   int
-	err  error
-	html template.HTML
-	s    goatcounter.WidgetSettings
+	id     int
+	loaded bool
+	err    error
+	html   template.HTML
+	s      goatcounter.WidgetSettings
 
 	Ref                    string
 	Style                  string
@@ -40,6 +41,7 @@ func (w *Pages) SetHTML(h template.HTML)             { w.html = h }
 func (w Pages) HTML() template.HTML                  { return w.html }
 func (w *Pages) SetErr(h error)                      { w.err = h }
 func (w Pages) Err() error                           { return w.err }
+func (w Pages) ID() int                              { return w.id }
 func (w Pages) Settings() goatcounter.WidgetSettings { return w.s }
 
 func (w *Pages) SetSettings(s goatcounter.WidgetSettings) {
@@ -82,6 +84,7 @@ func (w *Pages) GetData(ctx context.Context, a Args) (bool, error) {
 	errs.Append(err)
 
 	wg.Wait()
+	w.loaded = true
 	return w.More, errs.ErrorOrNil()
 }
 
@@ -92,11 +95,12 @@ func (w Pages) RenderHTML(ctx context.Context, shared SharedData) (string, inter
 			Site    *goatcounter.Site
 			User    *goatcounter.User
 			ID      int
+			Loaded  bool
 			Err     error
 
 			Refs        goatcounter.HitStats
 			CountUnique int
-		}{ctx, shared.Site, shared.User, w.id, w.err,
+		}{ctx, shared.Site, shared.User, w.id, w.loaded, w.err,
 			w.Refs, shared.TotalUnique}
 	}
 
@@ -149,6 +153,7 @@ func (w Pages) RenderHTML(ctx context.Context, shared SharedData) (string, inter
 		User    *goatcounter.User
 
 		ID          int
+		Loaded      bool
 		Err         error
 		Pages       goatcounter.HitLists
 		Period      ztime.Range
@@ -171,7 +176,7 @@ func (w Pages) RenderHTML(ctx context.Context, shared SharedData) (string, inter
 		ShowRefs string
 	}{
 		ctx, shared.Site, shared.User,
-		w.id, w.err, w.Pages, shared.Args.Rng, shared.Args.Daily,
+		w.id, w.loaded, w.err, w.Pages, shared.Args.Rng, shared.Args.Daily,
 		shared.Args.ForcedDaily, 1, w.Max, w.Display,
 		w.UniqueDisplay, shared.Total, shared.TotalUnique, shared.TotalEvents, shared.TotalEventsUnique,
 		w.More, w.Style, w.Refs, shared.Args.ShowRefs,

--- a/widgets/sizes.go
+++ b/widgets/sizes.go
@@ -13,10 +13,11 @@ import (
 )
 
 type Sizes struct {
-	id   int
-	err  error
-	html template.HTML
-	s    goatcounter.WidgetSettings
+	id     int
+	loaded bool
+	err    error
+	html   template.HTML
+	s      goatcounter.WidgetSettings
 
 	Limit  int
 	Detail string
@@ -30,6 +31,7 @@ func (w *Sizes) SetHTML(h template.HTML)             { w.html = h }
 func (w Sizes) HTML() template.HTML                  { return w.html }
 func (w *Sizes) SetErr(h error)                      { w.err = h }
 func (w Sizes) Err() error                           { return w.err }
+func (w Sizes) ID() int                              { return w.id }
 func (w Sizes) Settings() goatcounter.WidgetSettings { return w.s }
 
 func (w *Sizes) SetSettings(s goatcounter.WidgetSettings) {
@@ -45,6 +47,7 @@ func (w *Sizes) GetData(ctx context.Context, a Args) (more bool, err error) {
 	} else {
 		err = w.Stats.ListSizes(ctx, a.Rng, a.PathFilter)
 	}
+	w.loaded = true
 	return w.Stats.More, err
 }
 
@@ -54,13 +57,14 @@ func (w Sizes) RenderHTML(ctx context.Context, shared SharedData) (string, inter
 		ID             int
 		RowsOnly       bool
 		HasSubMenu     bool
+		Loaded         bool
 		Err            error
 		IsCollected    bool
 		Header         string
 		TotalUniqueUTC int
 		Stats          goatcounter.HitStats
 		Detail         string
-	}{ctx, w.id, shared.RowsOnly, true, w.err, isCol(ctx, goatcounter.CollectScreenSize),
+	}{ctx, w.id, shared.RowsOnly, true, w.loaded, w.err, isCol(ctx, goatcounter.CollectScreenSize),
 		z18n.T(ctx, "header/sizes|Sizes"),
 		shared.TotalUniqueUTC, w.Stats, w.Detail}
 }

--- a/widgets/systems.go
+++ b/widgets/systems.go
@@ -13,10 +13,11 @@ import (
 )
 
 type Systems struct {
-	id   int
-	err  error
-	html template.HTML
-	s    goatcounter.WidgetSettings
+	id     int
+	loaded bool
+	err    error
+	html   template.HTML
+	s      goatcounter.WidgetSettings
 
 	Limit  int
 	Detail string
@@ -32,6 +33,7 @@ func (w *Systems) SetHTML(h template.HTML)             { w.html = h }
 func (w Systems) HTML() template.HTML                  { return w.html }
 func (w *Systems) SetErr(h error)                      { w.err = h }
 func (w Systems) Err() error                           { return w.err }
+func (w Systems) ID() int                              { return w.id }
 func (w Systems) Settings() goatcounter.WidgetSettings { return w.s }
 
 func (w *Systems) SetSettings(s goatcounter.WidgetSettings) {
@@ -50,6 +52,7 @@ func (w *Systems) GetData(ctx context.Context, a Args) (more bool, err error) {
 	} else {
 		err = w.Stats.ListSystems(ctx, a.Rng, a.PathFilter, w.Limit, a.Offset)
 	}
+	w.loaded = true
 	return w.Stats.More, err
 }
 
@@ -59,13 +62,14 @@ func (w Systems) RenderHTML(ctx context.Context, shared SharedData) (string, int
 		ID             int
 		RowsOnly       bool
 		HasSubMenu     bool
+		Loaded         bool
 		Err            error
 		IsCollected    bool
 		Header         string
 		TotalUniqueUTC int
 		Stats          goatcounter.HitStats
 		Detail         string
-	}{ctx, w.id, shared.RowsOnly, true, w.err, isCol(ctx, goatcounter.CollectUserAgent),
+	}{ctx, w.id, shared.RowsOnly, true, w.loaded, w.err, isCol(ctx, goatcounter.CollectUserAgent),
 		z18n.T(ctx, "header/systems|Systems"),
 		shared.TotalUniqueUTC, w.Stats, w.Detail}
 }

--- a/widgets/toprefs.go
+++ b/widgets/toprefs.go
@@ -13,10 +13,11 @@ import (
 )
 
 type TopRefs struct {
-	id   int
-	err  error
-	html template.HTML
-	s    goatcounter.WidgetSettings
+	id     int
+	loaded bool
+	err    error
+	html   template.HTML
+	s      goatcounter.WidgetSettings
 
 	Limit   int
 	Ref     string
@@ -30,6 +31,7 @@ func (w *TopRefs) SetHTML(h template.HTML)             { w.html = h }
 func (w TopRefs) HTML() template.HTML                  { return w.html }
 func (w *TopRefs) SetErr(h error)                      { w.err = h }
 func (w TopRefs) Err() error                           { return w.err }
+func (w TopRefs) ID() int                              { return w.id }
 func (w TopRefs) Settings() goatcounter.WidgetSettings { return w.s }
 
 func (w *TopRefs) SetSettings(s goatcounter.WidgetSettings) {
@@ -48,6 +50,7 @@ func (w *TopRefs) GetData(ctx context.Context, a Args) (more bool, err error) {
 	} else {
 		err = w.TopRefs.ListTopRefs(ctx, a.Rng, a.PathFilter, w.Limit, a.Offset)
 	}
+	w.loaded = true
 	return w.TopRefs.More, err
 }
 
@@ -56,11 +59,12 @@ func (w TopRefs) RenderHTML(ctx context.Context, shared SharedData) (string, int
 		Context     context.Context
 		ID          int
 		RowsOnly    bool
+		Loaded      bool
 		Err         error
 		IsCollected bool
 		TotalUnique int
 		Stats       goatcounter.HitStats
 		Ref         string
-	}{ctx, w.id, shared.RowsOnly, w.err, isCol(ctx, goatcounter.CollectReferrer),
+	}{ctx, w.id, shared.RowsOnly, w.loaded, w.err, isCol(ctx, goatcounter.CollectReferrer),
 		shared.TotalUnique, w.TopRefs, w.Ref}
 }

--- a/widgets/total_pages.go
+++ b/widgets/total_pages.go
@@ -14,10 +14,11 @@ import (
 )
 
 type TotalPages struct {
-	id   int
-	err  error
-	html template.HTML
-	s    goatcounter.WidgetSettings
+	id     int
+	loaded bool
+	err    error
+	html   template.HTML
+	s      goatcounter.WidgetSettings
 
 	Align, NoEvents bool
 	Style           string
@@ -34,6 +35,7 @@ func (w *TotalPages) SetHTML(h template.HTML)             { w.html = h }
 func (w TotalPages) HTML() template.HTML                  { return w.html }
 func (w *TotalPages) SetErr(h error)                      { w.err = h }
 func (w TotalPages) Err() error                           { return w.err }
+func (w TotalPages) ID() int                              { return w.id }
 func (w TotalPages) Settings() goatcounter.WidgetSettings { return w.s }
 
 func (w *TotalPages) SetSettings(s goatcounter.WidgetSettings) {
@@ -51,6 +53,7 @@ func (w *TotalPages) SetSettings(s goatcounter.WidgetSettings) {
 
 func (w *TotalPages) GetData(ctx context.Context, a Args) (more bool, err error) {
 	w.Max, err = w.Total.Totals(ctx, a.Rng, a.PathFilter, a.Daily, w.NoEvents)
+	w.loaded = true
 	return false, err
 }
 
@@ -78,6 +81,7 @@ func (w TotalPages) RenderHTML(ctx context.Context, shared SharedData) (string, 
 		Site    *goatcounter.Site
 		User    *goatcounter.User
 		ID      int
+		Loaded  bool
 		Err     error
 
 		Align             bool
@@ -90,7 +94,7 @@ func (w TotalPages) RenderHTML(ctx context.Context, shared SharedData) (string, 
 		TotalEvents       int
 		TotalEventsUnique int
 		Style             string
-	}{ctx, shared.Site, shared.User, w.id, w.err,
+	}{ctx, shared.Site, shared.User, w.id, w.loaded, w.err,
 		w.Align, w.NoEvents,
 		w.Total, shared.Args.Daily, w.Max, shared.Total, shared.TotalUnique, shared.TotalEvents, shared.TotalEventsUnique,
 		w.Style}

--- a/widgets/widgets.go
+++ b/widgets/widgets.go
@@ -25,6 +25,7 @@ type (
 		Err() error
 		SetSettings(goatcounter.WidgetSettings)
 		Settings() goatcounter.WidgetSettings
+		ID() int
 
 		Name() string
 		Type() string // "full-width", "hchart"
@@ -110,7 +111,7 @@ func (l List) GetOne(name string) Widget {
 }
 
 // Get all widgets from the list by name.
-func (l List) Get(name string) []Widget {
+func (l List) Get(name string) List {
 	list := make([]Widget, 0, 1)
 	for _, w := range l {
 		if w.Name() == name {
@@ -118,6 +119,28 @@ func (l List) Get(name string) []Widget {
 		}
 	}
 	return list
+}
+
+// Initial gets all widgets that should be loaded on the initial pageview (all
+// internal widgets + the first one).
+func (l List) InitialAndLazy() (initial List, lazy List) {
+	first := true
+	initial = make(List, 0, 3)
+	lazy = make(List, 0, len(l)-3)
+	for _, w := range l {
+		switch w.Name() {
+		case "max", "totalcount":
+			initial = append(initial, w)
+		default:
+			if first {
+				initial = append(initial, w)
+				first = false
+			} else {
+				lazy = append(lazy, w)
+			}
+		}
+	}
+	return initial, lazy
 }
 
 // ListAllWidgets returns a static list of all widgets that this user can add.


### PR DESCRIPTION
Previously the entire dashboard would be loaded when someone requested
it: every "widget" would run its query in a goroutine, and everything
runs in parallel.

This works fairly well, and I like that you get either a full dashboard
or nothing at all, and for most people the dashboard loads in <1s (often
much faster), but for some of the largest sites this is causing
problems:

1. Getting the data can take a few seconds.
2. Running several queries (10 now on the default dashboard) in parallel
   slows down the individual queries.
3. The dashboard is only as fast as the slowest widget.

To improve this, we now "lazy load" the dashboard a bit more:

1. On the first request, we still load the "internal widgets" and the
   first widget like before, and render that immediately. We could "lazy
   load" everything, but I don't really like how that looks.
2. Start getting the data for the other widgets, and send a "request ID"
   to the frontend.
3. Push this out over the websocket once it's done.

This is a nice balance between "lazy load everything" and "wait for
everything to finish rendering on the server". The problem with lazy
loading everything is that for a lot of cases it *seems* slower as
rendering the HTML, parsing the JS, establishing the websocket takes a
bit, sending data over it, and rendering that all takes a bit of time.
For the cases where the dashboard already renders fast (<200ms, which is
most cases) all of this decreases the perceived performance.

In the future we could also use the websocket to push updates/reloads
instead of doing a jQuery.Ajax request.