### PR TITLE
Advanced documentation about PostgreSQL RDBMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,19 +214,29 @@ Use `goatcounter migrate pending` to get a list of pending migrations, or
 `goatcounter migrate list` to show all migrations.
 
 ### PostgreSQL
-To use PostgreSQL run GoatCounter with a custom `-db` flag; for example:
+To use PostgreSQL, first create the database; for example:
+
+	$ createuser --interactive --pwprompt goatcounter
+	$ createdb --owner goatcounter goatcounter
+	
+Configure the [HBA][hba] and reload the RDBMS. You can then import the schema; for example:
+
+	$ goatcounter db schema-pgsql | psql --user=goatcounter --dbname=goatcounter
+
+Then run GoatCounter with a custom `-db` flag; for example:
 
     $ goatcounter serve -db 'postgresql+dbname=goatcounter'
     $ goatcounter serve -db 'postgresql+host=/run/postgresql dbname=goatcounter sslmode=disable'
-	$ goatcounter serve -db 'postgresql://USER:PASS@example.org:PORT/goatcounter?sslmode=require'
+	$ goatcounter serve -db 'postgresql://USER:PASS@example.org:PORT/goatcounter?sslmode=require' # if remote
 
 This follows the format in the `psql` CLI; you can also use the `PG*`
 environment variables:
 
-   $ PGDATABASE=goatcounter DBHOST=/run/postgresql goatcounter serve -db 'postgresql'
+    $ PGDATABASE=goatcounter DBHOST=/run/postgresql goatcounter serve -db 'postgresql'
 
 See `goatcounter help db` and the [pq docs][pq] for more details.
 
+[hba]: https://www.postgresql.org/docs/current/auth-pg-hba-conf.html
 [pq]: https://pkg.go.dev/github.com/lib/pq#hdr-Connection_String_Parameters
 
 ### Development/testing

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ To use PostgreSQL run GoatCounter with a custom `-db` flag; for example:
 
     $ goatcounter serve -db 'postgresql+dbname=goatcounter'
     $ goatcounter serve -db 'postgresql+host=/run/postgresql dbname=goatcounter sslmode=disable'
+	$ goatcounter serve -db 'postgresql://USER:PASS@example.org:PORT/goatcounter?sslmode=require'
 
 This follows the format in the `psql` CLI; you can also use the `PG*`
 environment variables:


### PR DESCRIPTION
This PR adds the instructions required to quickly link GoatCounter to PostgreSQL from the command line.
It explains how to correctly:

1. create the database and a dedicated password-protected user;
2. associate the user role to the database;
3. make the database accessible;
4. import the schema produced by the executable of GoatCounter into the configured database;
5. optionally use a remote, password-protected database with an encrypted connection.

There are other ways to gain the same results by using a GUI or directly SQL, but this is the most predictable/repeatable way.

---

This will always work locally but remotely there might be further requirements (eg. configuring firewall rules and the database policy on SSL) which are better explained in dedicated websites. It is full responsibility of the system administrator to configure the kernel and the database parameters in such a way no sensitive informations is leaked when operating remotely.
Tested on Debian with PostgreSQL 13.