### PR TITLE
Fix rate limit name "api-count" → "apiCount"

### DIFF
--- a/cmd/goatcounter/serve.go
+++ b/cmd/goatcounter/serve.go
@@ -119,7 +119,7 @@ Flags:
 
                    count:4/1            4 requests / second
                    api:4/1              4 requests / seconds
-                   api-count:60/120    60 requests / 2 minutes
+                   apiCount:60/120     60 requests / 2 minutes
                    export:1/3600        1 requests / hour
                    login:20/60         20 requests / minute
 
@@ -357,7 +357,7 @@ func flagsServe(f zli.Flags, v *zvalidate.Validator) (string, string, bool, bool
 			v.Required("name", name)
 			v.Required("requests", reqs)
 			v.Required("seconds", secs)
-			name = v.Include("name", name, []string{"count", "api", "api-count", "export", "login"})
+			name = v.Include("name", name, []string{"count", "api", "apiCount", "export", "login"})
 			r := v.Integer("requests", reqs)
 			s := v.Integer("seconds", secs)
 			if v.HasErrors() {

--- a/cmd/goatcounter/serve.go
+++ b/cmd/goatcounter/serve.go
@@ -119,7 +119,7 @@ Flags:
 
                    count:4/1            4 requests / second
                    api:4/1              4 requests / seconds
-                   apiCount:60/120     60 requests / 2 minutes
+                   api-count:60/120    60 requests / 2 minutes
                    export:1/3600        1 requests / hour
                    login:20/60         20 requests / minute
 
@@ -357,7 +357,7 @@ func flagsServe(f zli.Flags, v *zvalidate.Validator) (string, string, bool, bool
 			v.Required("name", name)
 			v.Required("requests", reqs)
 			v.Required("seconds", secs)
-			name = v.Include("name", name, []string{"count", "api", "apiCount", "export", "login"})
+			name = v.Include("name", name, []string{"count", "api", "api-count", "export", "login"})
 			r := v.Integer("requests", reqs)
 			s := v.Integer("seconds", secs)
 			if v.HasErrors() {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"zgo.at/goatcounter/v2"
@@ -32,12 +33,12 @@ var rateLimits = struct {
 // Set the rate limits.
 func SetRateLimit(name string, reqs int, secs int64) {
 	r := mware.RatelimitLimit(reqs, secs)
-	switch name {
+	switch strings.ToLower(name) {
 	case "count":
 		rateLimits.count = r
 	case "api":
 		rateLimits.api = r
-	case "apiCount":
+	case "apicount", "api-count":
 		rateLimits.apiCount = r
 	case "export":
 		rateLimits.export = r


### PR DESCRIPTION
Setting rate limit for "apiCount" from the command line doesn't seem to work.

"apiCount" is invalid as far as the "-ratelimit" flag is concerned.

But "api-count" is then not a rate limit that is defined in handlers/handlers.go:

https://github.com/arp242/goatcounter/blob/a54ca4f6a007a329a096a2699668eed1a0221257/handlers/handlers.go#L40-L41