### PR TITLE
Add Cross-Origin-Resource-Policy `cross-origin` header for `/count`

### DIFF
--- a/handlers/count.go
+++ b/handlers/count.go
@@ -29,6 +29,7 @@ func (h backend) count(w http.ResponseWriter, r *http.Request) error {
 
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Content-Type", "image/gif")
+	w.Header().Set("Cross-Origin-Resource-Policy", "cross-origin")
 
 	// Note this works in both HTTP/1.1 and HTTP/2, as the Go HTTP/2 server
 	// picks up on this and sends the GOAWAY frame.


### PR DESCRIPTION
For users of goatcounter who want to have their site [`crossOriginIsolated`](https://web.dev/coop-coep) will need to set Cross-Origin-Embedder-Policy (COEP) to either `require-corp` or `credentialless`. COEP `require-corp` requires all subresources loaded to either be from the same-origin or have a [Cross-Origin-Resource-Policy (CORP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy#usage) header set.

Currently, goatcounter doesn't send a CORP header, which blocks users from setting COEP to `require-corp`. This commit sets CORP to `cross-origin` for the image pixel (`/count`) users fetch cross-origin, to allow users to achieve cross-origin isolation.

