### PR TITLE
Document postgres environment variable PGHOST

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,9 +216,9 @@ To use PostgreSQL run GoatCounter with a custom `-db` flag; for example:
     % goatcounter serve -db 'postgresql+host=/run/postgresql dbname=goatcounter sslmode=disable'
 
 This follows the format in the `psql` CLI; you can also use the `PG*`
-environment variables:
+[environment variables](https://www.postgresql.org/docs/current/libpq-envars.html):
 
-    % PGDATABASE=goatcounter DBHOST=/run/postgresql goatcounter serve -db 'postgresql'
+    % PGDATABASE=goatcounter PGHOST=/run/postgresql goatcounter serve -db 'postgresql'
 
 The database will be created automatically if possible; if you want to create it
 for a specific user you can use:

--- a/cmd/goatcounter/db.go
+++ b/cmd/goatcounter/db.go
@@ -295,7 +295,7 @@ PostgreSQL notes:
 
     You can also use the standard PG* environment variables:
 
-        PGDATABASE=goatcounter DBHOST=/var/run goatcounter -db 'postgresql'
+        PGDATABASE=goatcounter PGHOST=/var/run goatcounter -db 'postgresql'
 
     You may want to consider lowering the "seq_page_cost" parameter; the query
     planner tends to prefer seq scans instead of index scans for some operations


### PR DESCRIPTION
The documentation mentions an environment variable "DBHOST" to configure the postgres database, but I believe pq expects PGHOST (see https://www.postgresql.org/docs/current/libpq-envars.html)

Update the README and command help text with env var PGHOST and link to the relevant postgres documentation in the README.