### PR TITLE
Update translations with lingering num-views variable

### DIFF
--- a/i18n/fr-FR.toml
+++ b/i18n/fr-FR.toml
@@ -147,7 +147,7 @@
   default = "Totaux"
 
 ["dashboard/totals/num-visits"]
-  default = "%(num-visits) visites; %(num-views) pages vues"
+  default = "%(num-visits) visites"
 
 ["dashboard/week-ago"]
   default = "il y a %(n) semaines"

--- a/i18n/hi.toml
+++ b/i18n/hi.toml
@@ -137,7 +137,7 @@
   default = "योग"
 
 ["dashboard/totals/num-visits"]
-  default = "%(num-visits) विज़िट; %(num-views) पेज व्यू"
+  default = "%(num-visits) विज़िट"
 
 ["dashboard/week-ago"]
   default = "%(n) सप्ताह पहले"

--- a/i18n/ro-RO.toml
+++ b/i18n/ro-RO.toml
@@ -147,7 +147,7 @@
   default = "Totaluri"
 
 ["dashboard/totals/num-visits"]
-  default = "%(num-visits) vizite; %(num-views) vizualizari"
+  default = "%(num-visits) vizite"
 
 ["dashboard/week-ago"]
   default = "Acum %(n) saptamani"

--- a/i18n/ru-RU.toml
+++ b/i18n/ru-RU.toml
@@ -147,7 +147,7 @@
   default = "Итоги"
 
 ["dashboard/totals/num-visits"]
-  default = "Визитов %(num-visits); просмотров страниц %(num-views)"
+  default = "Визитов %(num-visits)"
 
 ["dashboard/week-ago"]
   default = "%(n) недель назад"


### PR DESCRIPTION
This variable was removed in https://github.com/arp242/goatcounter/commit/26392d10079a12aafa8621b57ddde2786ee0aed8, but some translations were not updated accordingly.

Here's the error I see in French:

![image](https://github.com/arp242/goatcounter/assets/6241083/58276aab-d326-4577-9dbf-125873d32db0)

I also updated the other affected languages, as it was easy to guess what to remove.