### PR TITLE
fix link to GDPR notices

### DIFF
--- a/tpl/help/privacy.md
+++ b/tpl/help/privacy.md
@@ -23,7 +23,7 @@ other methods.
 
 Also see the [GDPR consent notices].
 
-[GDPR consent notices]: /help/gdpr.html
+[GDPR consent notices]: /help/gdpr
 
 Sharing with third parties
 --------------------------


### PR DESCRIPTION
See <https://www.goatcounter.com/help/privacy>.

This link

![image](https://github.com/arp242/goatcounter/assets/13833017/e2b2b38d-f196-4f6f-b86d-0cfe8af26251)

does not work

![image](https://github.com/arp242/goatcounter/assets/13833017/b6618705-9b76-4a5c-973f-bbcb37396743)

I fix it.