### PR TITLE
better darkmode colors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	zgo.at/zlog v0.0.0-20211017235224-dd4772ddf860
 	zgo.at/zprof v0.0.0-20211217104121-c3c12596d8f0
 	zgo.at/zstd v0.0.0-20231206020926-f20b0b1e56be
-	zgo.at/ztpl v0.0.0-20231210165448-05891fb9a4df
+	zgo.at/ztpl v0.0.0-20240407165537-1af004e73b6e
 	zgo.at/zvalidate v0.0.0-20221021025449-cb54fa8efade
 )
 

--- a/go.sum
+++ b/go.sum
@@ -141,7 +141,7 @@ zgo.at/zprof v0.0.0-20211217104121-c3c12596d8f0 h1:nUshmGDnI3+N1OeU265xaqR6weTN2
 zgo.at/zprof v0.0.0-20211217104121-c3c12596d8f0/go.mod h1:JqClLxeT9Uui3apqyN3U6KryFanocqM7E3X4Gle2FAU=
 zgo.at/zstd v0.0.0-20231206020926-f20b0b1e56be h1:uCoZKZS+BrGcxNefHdxEVczvYcfb1hnRKss2l0/7zHQ=
 zgo.at/zstd v0.0.0-20231206020926-f20b0b1e56be/go.mod h1:o/Q8+EtSahHnfkbB3t8wXE0FnoDTmJ0sBDlzezv9XeM=
-zgo.at/ztpl v0.0.0-20231210165448-05891fb9a4df h1:Vrg1oQ+EhmxsSvGkm1am1D+T9ipR2l2YpRR7qolJelU=
-zgo.at/ztpl v0.0.0-20231210165448-05891fb9a4df/go.mod h1:6txfOkQuGYf3SOZ1qufjSxBMopsF3BVZrgC+EHY66oE=
+zgo.at/ztpl v0.0.0-20240407165537-1af004e73b6e h1:kTxj4JOH0U24lcbUb2KgnrkF4rsprr6nckwT7We1QNE=
+zgo.at/ztpl v0.0.0-20240407165537-1af004e73b6e/go.mod h1:6txfOkQuGYf3SOZ1qufjSxBMopsF3BVZrgC+EHY66oE=
 zgo.at/zvalidate v0.0.0-20221021025449-cb54fa8efade h1:eT6K9Iv+U3IPAmJVDCoRMbkbXL4NVeB0HaFob5J/hE0=
 zgo.at/zvalidate v0.0.0-20221021025449-cb54fa8efade/go.mod h1:E0pwS0q26cQtyWOOyzc7hEIMQgmtRC0xDIpEnrYct/8=

--- a/public/backend.css
+++ b/public/backend.css
@@ -80,6 +80,7 @@ input.red { border: 1px solid var(--input-error-border) !important; }
 .flash pre { text-align: left; margin: 0 auto; display: inline-block; }
 .flash-i   { background-color: var(--info-bg); border-color: var(--info-border); }
 .flash-e   { background-color: var(--error-bg); border-color: var(--error-border); }
+.onetime   { display:none; }
 
 .screen-reader { display: none; }
 .hide          { display: none; }

--- a/public/backend.js
+++ b/public/backend.js
@@ -16,7 +16,7 @@
 		if (!USER_SETTINGS.language)
 			USER_SETTINGS.language = 'en'
 
-		;[report_errors, bind_tooltip, bind_confirm, translate_calendar].forEach((f) => f.call())
+		;[report_errors, bind_tooltip, bind_confirm, translate_calendar, onetime].forEach((f) => f.call())
 		;[page_dashboard, page_settings_main, page_user_pref, page_user_dashboard, page_bosmang]
 			.forEach((f) => document.body.id.match(new RegExp('^' + f.name.replace(/_/g, '-'))) && f.call())
 	})
@@ -93,6 +93,26 @@
 
 			t.attr('data-title', title).removeAttr('title')
 			display(e, t)
+		})
+	}
+
+	// One-time messages.
+	let onetime = function() {
+		$('.onetime').each((_, elem) => {
+			elem = $(elem)
+			let n = elem.attr('class').split(' ').filter((v) => v.match(/^onetime-/))[0]
+			if (localStorage.getItem(n) ||
+				// People who don't have a dark theme won't see any change, so
+				// don't bother showing it to then.
+				(n === 'onetime-dark' && !window.matchMedia("(prefers-color-scheme: dark)").matches))
+				return
+
+			elem.css('display', 'block')
+			elem.find('.close').on('click', (e) => {
+				e.preventDefault()
+				elem.css('display', 'none')
+				localStorage.setItem(n, '1')
+			})
 		})
 	}
 

--- a/public/dark.css
+++ b/public/dark.css
@@ -1,8 +1,8 @@
 :root {
     --text:              #fff;
-    --bg:                #252525;
+    --bg:                rgba(0,0,0,0);
     --header-border:     #888;                             /* Border below some headers */
-    --backdrop:          #444;
+    --backdrop:          #0e1011;
     --target-bg:         #b78c1d;                          /* :target; mostly for headers in the documentation. */
     --loading-text:      #777;                             /* Little … that appears if something takes more than ~300ms to load */
 
@@ -33,12 +33,12 @@
     --tooltip-border:    #ddd;
     --tooltip-shadow:    #aaa;
 
-    --chart-line:        #6c0a73;                          /* Charts on the dashboard */
-    --chart-fill:        #ca56d3;
+    --chart-line:        #003996;                          /* Charts on the dashboard */
+    --chart-fill:        #003996;
     --chart-grid:        #555;
     --hchart-border:     #666;                             /* Colour when you hover the Browsers, Systems, etc. chart bar */
-    --hchart-bar:        #ebb7ef;
-    --hchart-bar-hover:  #f9cffc;
+    --hchart-bar:        #1e2123;
+    --hchart-bar-hover:  #0549b6;
 
     --nav-bg:            #1b093c;                          /* Navigation at dashboard, settings, and footer */
     --nav-border:        #3f1887;

--- a/tpl/_backend_top.gohtml
+++ b/tpl/_backend_top.gohtml
@@ -4,10 +4,15 @@
 	{{template "_favicon.gohtml" .}}
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>{{if .GoatcounterCom}}{{.Site.Code}} – {{end}}GoatCounter</title>
-	<link rel="stylesheet" href="{{.Static}}/vars.css?v={{.Version}}">
-	{{if eq .User.Settings.Theme "dark"}}
+	{{if eq .User.Settings.Theme "light"}}
+		<link rel="stylesheet" href="{{.Static}}/vars.css?v={{.Version}}">
+	{{else if eq .User.Settings.Theme "dark"}}
 		<link rel="stylesheet" href="{{.Static}}/dark.css?v={{.Version}}">
+	{{else}}
+		<link rel="stylesheet" href="{{.Static}}/vars.css?v={{.Version}}">
+		<link rel="stylesheet" href="{{.Static}}/dark.css?v={{.Version}}" media="(prefers-color-scheme: dark)">
 	{{end}}
+
 	<link rel="stylesheet" href="{{.Static}}/shared.css?v={{.Version}}">
 	<link rel="stylesheet" href="{{.Static}}/pikaday.css?v={{.Version}}">
 	<link rel="stylesheet" href="{{.Static}}/backend.css?v={{.Version}}">

--- a/tpl/_backend_top.gohtml
+++ b/tpl/_backend_top.gohtml
@@ -12,7 +12,6 @@
 		<link rel="stylesheet" href="{{.Static}}/vars.css?v={{.Version}}">
 		<link rel="stylesheet" href="{{.Static}}/dark.css?v={{.Version}}" media="(prefers-color-scheme: dark)">
 	{{end}}
-
 	<link rel="stylesheet" href="{{.Static}}/shared.css?v={{.Version}}">
 	<link rel="stylesheet" href="{{.Static}}/pikaday.css?v={{.Version}}">
 	<link rel="stylesheet" href="{{.Static}}/backend.css?v={{.Version}}">
@@ -91,3 +90,12 @@
 
 	<div class="page">
 	{{- if .Flash}}<div class="flash flash-{{.Flash.Level}}">{{.Flash.Message}}</div>{{end -}}
+
+	{{if and .User.ID (before .Site.CreatedAt "2024-04-07")}}
+		<div class="flash flash-i onetime onetime-dark">
+			The default theme colours are now set from your system; you can change it back to the
+			previous by changing it in <a href="/user/pref#section-email-reports">your user settings</a>
+			–
+			<a href="" class="close">don’t show again</a>
+		</div>
+	{{end}}

--- a/tpl/user_pref.gohtml
+++ b/tpl/user_pref.gohtml
@@ -115,10 +115,8 @@
 
 			<label for="theme">{{.T "label/theme|Theme"}}</label>
 			<select id="theme" name="theme">
-				{{/*
 				<option {{option_value .User.Settings.Theme ""}}>{{.T "theme/system|Use system setting"}}</option>
-				*/}}
-				<option {{option_value .User.Settings.Theme ""}}>{{.T "theme/light|Light"}}</option>
+				<option {{option_value .User.Settings.Theme "light"}}>{{.T "theme/light|Light"}}</option>
 				<option {{option_value .User.Settings.Theme "dark"}}>{{.T "theme/dark|Dark"}}</option>
 			</select>
 


### PR DESCRIPTION
|before|after|
|-|-|
|![image](https://github.com/arp242/goatcounter/assets/72335827/d0d851f5-51b0-4245-b12f-6717d0f4cff3)|![image](https://github.com/arp242/goatcounter/assets/72335827/71a710c7-e0d8-4472-9e03-7ed74e8ea7e3)|

I got the colors from the cloudflare dashboard as they were pretty good in my opinion,
also should i make it detect if the user wants darkmode and apply it then?