### PR TITLE
fix link to sessions page

### DIFF
--- a/tpl/home.gohtml
+++ b/tpl/home.gohtml
@@ -56,7 +56,7 @@
 	<div>
 		<p>Identify <strong>unique visits</strong> without cookies or
 			persistently storing any personal data
-			(<a href="{{.Base}}/help/sessions.md">details</a>).</p>
+			(<a href="{{.Base}}/help/sessions">details</a>).</p>
 
 		<p>Keeps useful statistics such as <strong>browser</strong> information,
 			<strong>location</strong>, and <strong>screen size</strong>. Keep


### PR DESCRIPTION
This link on https://www.goatcounter.com/ is broken:
<img width="559" alt="Screenshot 2025-02-04 at 15 08 00" src="https://github.com/user-attachments/assets/cba3985c-2e50-4329-9cb6-923c45d5e704" />

it links to https://www.goatcounter.com/help/sessions.md, but it should link to https://www.goatcounter.com/help/sessions

### Bad destination
![Screenshot 2025-02-04 at 15 03 03](https://github.com/user-attachments/assets/153ec1f0-02a6-4f6c-ad07-7abaaaed5958)

### Good destination
![Screenshot 2025-02-04 at 15 03 33](https://github.com/user-attachments/assets/b1bbf9db-2c2a-4b06-9fa2-73c0bc1d8787)

# Testing
I tried reproing the fix locally, but I couldn't figure out how to navigate to the root documentation page. When I click *Home* in the bottom left, it brings me to www.goatcounter.com rather than something like http://www.goatcounter.localhost:443/home.gohtml or whatever. I scanned the CONTRIBUTING.md guide and didn't immediately figure it out, so i never was able to test

![Screenshot 2025-02-04 at 15 05 35](https://github.com/user-attachments/assets/30faff3f-8b7c-4a12-9dc7-c8a0354bbf61)
