### PR TITLE
Implement time.Unix and time.UnixMilli for custom log files

### DIFF
--- a/cmd/goatcounter/import.go
+++ b/cmd/goatcounter/import.go
@@ -183,6 +183,8 @@ Date and time parsing:
 
         ansic          Mon Jan _2 15:04:05 2006
         unix           Mon Jan _2 15:04:05 MST 2006
+        unixmilli      1746644937044
+        unixsec        1746644937
         rfc822         02 Jan 06 15:04 MST
         rfc822z        02 Jan 06 15:04 -0700
         rfc850         Monday, 02-Jan-06 15:04:05 MST

--- a/logscan/regex_parser.go
+++ b/logscan/regex_parser.go
@@ -238,7 +238,24 @@ func (l RegexLine) Datetime(scan *Scanner) (time.Time, error) {
 	}
 	s, ok = l["datetime"]
 	if ok {
-		t, err := time.Parse(parser.datetime, s)
+		var t time.Time
+		var err error
+		switch parser.datetime {
+		case "unixmilli":
+			i, err := strconv.ParseInt(s, 10, 64)
+			if err != nil {
+				return t.UTC(), err
+			}
+			t = time.UnixMilli(i)
+		case "unixsec":
+			i, err := strconv.ParseInt(s, 10, 64)
+			if err != nil {
+				return t.UTC(), err
+			}
+			t = time.Unix(i, 0)
+		default:
+			t, err = time.Parse(parser.datetime, s)
+		}
 		return t.UTC(), err
 	}
 	return time.Time{}, nil
@@ -248,6 +265,7 @@ func toI(s string) int {
 	n, _ := strconv.Atoi(s) // Regexp only captures \d, so safe to ignore.
 	return n
 }
+
 func toI64(s string) int64 {
 	n, _ := strconv.ParseInt(s, 10, 64)
 	return n


### PR DESCRIPTION
For my specific workflow I need to parse custom log files that contain `UnixMilli` timestamps. I hence implemented `UnixMilli` (and `Unix` for convenience) for use with `-datetime` (`$datetime`).

I did not quite understand the (practical) difference of `time`, `date`, and `datetime`, as the code appears to be doing the same exact thing. However, as a Unix (milli)seconds timestamp always contains of a date and a time, I only implemented it for `datetime`.