### PR TITLE
Don't run docker/login-action on PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: 'actions/checkout@v4'
       - uses: 'docker/setup-buildx-action@v3'
       - uses: 'docker/login-action@v3'
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
This fails as PRs from other people won't have the credentials set. It's also not needed as we won't push on PRs.