### PR TITLE
Unmarshall SiteIDs properly so that import works

### DIFF
--- a/cmd/goatcounter/import.go
+++ b/cmd/goatcounter/import.go
@@ -237,6 +237,9 @@ func cmdImport(f zli.Flags, ready chan<- struct{}, stop chan struct{}) error {
 		if len(files) > 1 {
 			return fmt.Errorf("can only specify one filename")
 		}
+		if site == "" {
+			return fmt.Errorf("-site needs to be set")
+		}
 
 		var fp io.ReadCloser
 		if files[0] == "-" {

--- a/site.go
+++ b/site.go
@@ -36,6 +36,15 @@ type (
 	SiteIDs []SiteID
 )
 
+func (s *SiteIDs) UnmarshalJSON(data []byte) error {
+	var tmp []SiteID
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	*s = tmp
+	return nil
+}
+
 // func (s SiteIDs) MarshalText() ([]byte, error) { return json.Marshal(s) }
 func (s *SiteIDs) UnmarshalText(v []byte) error {
 	n, err := zstrconv.ParseInt[SiteID](string(v), 10)


### PR DESCRIPTION
imports fail with `goatcounter: json: cannot unmarshal array into Go struct field APIToken.token.sites of type goatcounter.SiteIDs
` otherwise