### PR TITLE
Expand filter syntax

### DIFF
--- a/db/query/paths.PathFilter.sql
+++ b/db/query/paths.PathFilter.sql
@@ -4,9 +4,11 @@ where
 	{{:only_event    and event=1}}
 	{{:only_pageview and event=0}}
 	and (
-		lower(path) like lower(:filter)
-		{{:match_title or lower(title) like lower(:filter)}}
+		{{:match_path  lower(path)  :not like lower(:filter)}}
+		:or
+		{{:match_title lower(title) :not like lower(:filter)}}
 	)
+
 -- The limit is here because that's the limit in SQL parameters; the returned
 -- []int64 is passed as parameters later on.
 --

--- a/handlers/dashboard.go
+++ b/handlers/dashboard.go
@@ -85,7 +85,7 @@ func (h backend) dashboard(w http.ResponseWriter, r *http.Request) error {
 			err   error
 		)
 		if view.Filter != "" {
-			f, err = goatcounter.PathFilter(r.Context(), view.Filter, true)
+			f, err = goatcounter.PathFilter(r.Context(), view.Filter)
 		}
 		pathFilter <- struct {
 			Paths []goatcounter.PathID
@@ -448,7 +448,7 @@ func getPathFilter(v *zvalidate.Validator, r *http.Request) []goatcounter.PathID
 		return nil
 	}
 
-	filter, err := goatcounter.PathFilter(r.Context(), f, true)
+	filter, err := goatcounter.PathFilter(r.Context(), f)
 	if err != nil {
 		v.Append("filter", err.Error())
 	}

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -127,6 +127,8 @@ func newGlobals(w http.ResponseWriter, r *http.Request) Globals {
 			"datepicker/keyboard":         T(ctx, "datepicker/keyboard|Use the arrow keys to pick a date"),
 			"datepicker/month-prev":       T(ctx, "datepicker/month-prev|Previous month"),
 			"datepicker/month-next":       T(ctx, "datepicker/month-next|Next month"),
+			"nav-dash/filter-more-help":   T(ctx, "nav-dash/filter-more-help|More help"),
+			"nav-fash/filter-less-help":   T(ctx, "nav-fash/filter-less-help|Less help"),
 		},
 	}
 	if g.User == nil {

--- a/hit_list_test.go
+++ b/hit_list_test.go
@@ -158,7 +158,7 @@ func TestHitListsList(t *testing.T) {
 
 			gctest.StoreHits(ctx, t, false, tt.in...)
 
-			pathsFilter, err := PathFilter(ctx, tt.inFilter, true)
+			pathsFilter, err := PathFilter(ctx, tt.inFilter)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/i18n/de-DE.toml
+++ b/i18n/de-DE.toml
@@ -820,7 +820,18 @@ Eigene Domain, z.B. <em>„stats.example.com“</em>.
   default = "Pfade filtern"
 
 ["nav-dash/filter-tooltip"]
-  default = "Pfadliste filtern; ignoriert Groß-/Kleinschreibung auf Pfad und Titel"
+  default = """<p>Pfadliste filtern; ignoriert Groß-/Kleinschreibung auf Pfad und Titel. %[%more More help]</p>
+
+	<div>
+		<p>Recognizes the following keywords:</p>
+		<ul>
+			<li><em>at:start</em>, <em>at:end</em>:       match only at the start or end of path or title. Use both for exact match.</li>
+			<li><em>in:path</em>, <em>in:title</em>       match only path or title.</li>
+			<li><em>is:event</em>, <em>is:pageview</em>   show only events or pageviews.</li>
+			<li><em>:not</em> negate the match (that is: only show paths that don't match the filter).</li>
+		</ul>
+	</div>
+  """
 
 ["nav-dash/forced-daily"]
   default = "Stündliche Anzeige bei Zeitraum über 90 Tagen nicht möglich"

--- a/i18n/es-CL.toml
+++ b/i18n/es-CL.toml
@@ -823,7 +823,18 @@ Martin
   default = "Filtrar rutas"
 
 ["nav-dash/filter-tooltip"]
-  default = "Filtrar la lista de rutas; coincidirá con la ruta y el título"
+  default = """<p>Filtrar la lista de rutas; coincidirá con la ruta y el título. %[%more More help]</p>
+
+	<div>
+		<p>Recognizes the following keywords:</p>
+		<ul>
+			<li><em>at:start</em>, <em>at:end</em>:       match only at the start or end of path or title. Use both for exact match.</li>
+			<li><em>in:path</em>, <em>in:title</em>       match only path or title.</li>
+			<li><em>is:event</em>, <em>is:pageview</em>   show only events or pageviews.</li>
+			<li><em>:not</em> negate the match (that is: only show paths that don't match the filter).</li>
+		</ul>
+	</div>
+  """
 
 ["nav-dash/forced-daily"]
   default = "No se puede usar la vista de cada hora para un rango de tiempo de más de 90 días"

--- a/i18n/fr-FR.toml
+++ b/i18n/fr-FR.toml
@@ -825,7 +825,18 @@ Nécessite un plan Personal Plus ou Business (vous êtes sur le plan \\"%(plan)\
   default = "Filtrer les pages"
 
 ["nav-dash/filter-tooltip"]
-  default = "Filtre la liste des pages selon chemin ou titre (sans tenir compte maj/min)"
+  default = """<p>Filtre la liste des pages selon chemin ou titre (sans tenir compte maj/min). %[%more More help]</p>
+
+	<div>
+		<p>Recognizes the following keywords:</p>
+		<ul>
+			<li><em>at:start</em>, <em>at:end</em>:       match only at the start or end of path or title. Use both for exact match.</li>
+			<li><em>in:path</em>, <em>in:title</em>       match only path or title.</li>
+			<li><em>is:event</em>, <em>is:pageview</em>   show only events or pageviews.</li>
+			<li><em>:not</em> negate the match (that is: only show paths that don't match the filter).</li>
+		</ul>
+	</div>
+  """
 
 ["nav-dash/forced-daily"]
   default = "Impossible d'utiliser la vue horaire pour une période de plus de 90 jours"

--- a/i18n/id-ID.toml
+++ b/i18n/id-ID.toml
@@ -822,7 +822,18 @@ Verifikasi akan dijalankan setiap 2 jam.
   default = "Saring jalur"
 
 ["nav-dash/filter-tooltip"]
-  default = "Saring daftar jalur; tidak berpengaruh oleh huruf besar/kecil dan dicocokkan pada jalur dan judul"
+  default = """<p>Saring daftar jalur; tidak berpengaruh oleh huruf besar/kecil dan dicocokkan pada jalur dan judul. %[%more More help]</p>
+
+	<div>
+		<p>Recognizes the following keywords:</p>
+		<ul>
+			<li><em>at:start</em>, <em>at:end</em>:       match only at the start or end of path or title. Use both for exact match.</li>
+			<li><em>in:path</em>, <em>in:title</em>       match only path or title.</li>
+			<li><em>is:event</em>, <em>is:pageview</em>   show only events or pageviews.</li>
+			<li><em>:not</em> negate the match (that is: only show paths that don't match the filter).</li>
+		</ul>
+	</div>
+  """
 
 ["nav-dash/forced-daily"]
   default = "Tidak dapat menggunakan tampilan per jam untuk jangka waktu lebih dari 90 hari"

--- a/i18n/it-IT.toml
+++ b/i18n/it-IT.toml
@@ -827,7 +827,18 @@ La verifica è effettuata ogni 2 ore.
   default = "Filtra i percorsi"
 
 ["nav-dash/filter-tooltip"]
-  default = "Filtra la lista di percorsi; controlli case-insensitive su path e titolo"
+  default = """<p>Filtra la lista di percorsi; controlli case-insensitive su path e titolo. %[%more More help]</p>
+
+	<div>
+		<p>Recognizes the following keywords:</p>
+		<ul>
+			<li><em>at:start</em>, <em>at:end</em>:       match only at the start or end of path or title. Use both for exact match.</li>
+			<li><em>in:path</em>, <em>in:title</em>       match only path or title.</li>
+			<li><em>is:event</em>, <em>is:pageview</em>   show only events or pageviews.</li>
+			<li><em>:not</em> negate the match (that is: only show paths that don't match the filter).</li>
+		</ul>
+	</div>
+  """
 
 ["nav-dash/forced-daily"]
   default = "Non è possibile utilizzare viste orarie per un range superiore a 90 giorni"

--- a/i18n/ja-JP.toml
+++ b/i18n/ja-JP.toml
@@ -808,7 +808,18 @@ Martin
   default = "パスで絞り込む"
 
 ["nav-dash/filter-tooltip"]
-  default = "パスとタイトルを大文字小文字の区別なしで絞り込みます"
+  default = """<p>パスとタイトルを大文字小文字の区別なしで絞り込みます. %[%more More help]</p>
+
+	<div>
+		<p>Recognizes the following keywords:</p>
+		<ul>
+			<li><em>at:start</em>, <em>at:end</em>:       match only at the start or end of path or title. Use both for exact match.</li>
+			<li><em>in:path</em>, <em>in:title</em>       match only path or title.</li>
+			<li><em>is:event</em>, <em>is:pageview</em>   show only events or pageviews.</li>
+			<li><em>:not</em> negate the match (that is: only show paths that don't match the filter).</li>
+		</ul>
+	</div>
+  """
 
 ["nav-dash/forced-daily"]
   default = "表示期間が 90 日を超える場合、時刻は表示できません"

--- a/i18n/ko-KR.toml
+++ b/i18n/ko-KR.toml
@@ -818,7 +818,18 @@
   default = "경로 필터"
 
 ["nav-dash/filter-tooltip"]
-  default = "경로 목록을 필터링합니다. 경로와 제목에 대해 대소문자를 구분하지 않고 일치시킵니다."
+  default = """<p>경로 목록을 필터링합니다. 경로와 제목에 대해 대소문자를 구분하지 않고 일치시킵니다. %[%more More help]</p>
+
+	<div>
+		<p>Recognizes the following keywords:</p>
+		<ul>
+			<li><em>at:start</em>, <em>at:end</em>:       match only at the start or end of path or title. Use both for exact match.</li>
+			<li><em>in:path</em>, <em>in:title</em>       match only path or title.</li>
+			<li><em>is:event</em>, <em>is:pageview</em>   show only events or pageviews.</li>
+			<li><em>:not</em> negate the match (that is: only show paths that don't match the filter).</li>
+		</ul>
+	</div>
+  """
 
 ["nav-dash/forced-daily"]
   default = "90일 이상의 시간 범위에 대해 시간별 보기를 사용할 수 없습니다."

--- a/i18n/nl-NL.toml
+++ b/i18n/nl-NL.toml
@@ -827,7 +827,18 @@ of een andere reden. Dit is compleet optioneel.
   default = "Filter paden"
 
 ["nav-dash/filter-tooltip"]
-  default = "Filter de lijst met paden; hoofdletter ongevoelig en filtert op de padnaam en titel"
+  default = """<p>Filter de lijst met paden; hoofdletter ongevoelig en filtert op de padnaam en titel. %[%more Meer help]</p>
+
+	<div>
+		<p>Recognizes the following keywords:</p>
+		<ul>
+			<li><em>at:start</em>, <em>at:end</em>:       match only at the start or end of path or title. Use both for exact match.</li>
+			<li><em>in:path</em>, <em>in:title</em>       match only path or title.</li>
+			<li><em>is:event</em>, <em>is:pageview</em>   show only events or pageviews.</li>
+			<li><em>:not</em> negate the match (that is: only show paths that don't match the filter).</li>
+		</ul>
+	</div>
+  """
 
 ["nav-dash/forced-daily"]
   default = "Kan niet per uur bekijken voor meer dan 90 dagen"

--- a/i18n/pl-PL.toml
+++ b/i18n/pl-PL.toml
@@ -830,7 +830,18 @@ Weryfikacja odbywa się co 2 godziny.
   default = "Filtruj ścieżki"
 
 ["nav-dash/filter-tooltip"]
-  default = "Filtruj listę ścieżek; uwzględniaj wielkość liter ścieżek i tytułów"
+  default = """<p>Filtruj listę ścieżek; uwzględniaj wielkość liter ścieżek i tytułów. %[%more More help]</p>
+
+	<div>
+		<p>Recognizes the following keywords:</p>
+		<ul>
+			<li><em>at:start</em>, <em>at:end</em>:       match only at the start or end of path or title. Use both for exact match.</li>
+			<li><em>in:path</em>, <em>in:title</em>       match only path or title.</li>
+			<li><em>is:event</em>, <em>is:pageview</em>   show only events or pageviews.</li>
+			<li><em>:not</em> negate the match (that is: only show paths that don't match the filter).</li>
+		</ul>
+	</div>
+  """
 
 ["nav-dash/forced-daily"]
   default = "Widok godzinny niedostępny dla zakresu dat powyżej 90 dni"

--- a/i18n/pt-BR.toml
+++ b/i18n/pt-BR.toml
@@ -819,7 +819,18 @@ A verificação é executada a cada 2 horas.
   default = "Filtrar caminhos"
 
 ["nav-dash/filter-tooltip"]
-  default = "Filtrar a lista de caminhos sem diferenciação entre maiúsculas e minúsculas no título e no caminho."
+  default = """<p>Filtrar a lista de caminhos sem diferenciação entre maiúsculas e minúsculas no título e no caminho. %[%more More help]</p>
+
+	<div>
+		<p>Recognizes the following keywords:</p>
+		<ul>
+			<li><em>at:start</em>, <em>at:end</em>:       match only at the start or end of path or title. Use both for exact match.</li>
+			<li><em>in:path</em>, <em>in:title</em>       match only path or title.</li>
+			<li><em>is:event</em>, <em>is:pageview</em>   show only events or pageviews.</li>
+			<li><em>:not</em> negate the match (that is: only show paths that don't match the filter).</li>
+		</ul>
+	</div>
+  """
 
 ["nav-dash/forced-daily"]
   default = "A visualização por hora não pode ser usada em um período de tempo superior a 90 dias."

--- a/i18n/sk-SK.toml
+++ b/i18n/sk-SK.toml
@@ -821,7 +821,18 @@ Martin
   default = "Filtrovať cesty"
 
 ["nav-dash/filter-tooltip"]
-  default = "Filtrovať zoznamy ciest; pri cestách a nadpisoch sa nerozlišujú malé a veľké písmená"
+  default = """<p>Filtrovať zoznamy ciest; pri cestách a nadpisoch sa nerozlišujú malé a veľké písmená. %[%more More help]</p>
+
+	<div>
+		<p>Recognizes the following keywords:</p>
+		<ul>
+			<li><em>at:start</em>, <em>at:end</em>:       match only at the start or end of path or title. Use both for exact match.</li>
+			<li><em>in:path</em>, <em>in:title</em>       match only path or title.</li>
+			<li><em>is:event</em>, <em>is:pageview</em>   show only events or pageviews.</li>
+			<li><em>:not</em> negate the match (that is: only show paths that don't match the filter).</li>
+		</ul>
+	</div>
+  """
 
 ["nav-dash/forced-daily"]
   default = "Nemožno použiť hodinový pohľad pre časové rozmedzie väčšie ako 90 dní"

--- a/i18n/template.toml
+++ b/i18n/template.toml
@@ -1185,7 +1185,17 @@ for wanting to delete your account. This is entirely optional.
 
 ["nav-dash/filter-tooltip"]
   loc     = ["tpl/dashboard.gohtml:98"]
-  default = "Filter the list of paths; matched case-insensitive on path and title"
+  default = """<p>Filter the list of paths; matched case-insensitive on path and title. %[%more More help]</p>
+
+	<div>
+		<p>Recognizes the following keywords:</p>
+		<ul>
+			<li><em>at:start</em>, <em>at:end</em>:       match only at the start or end of path or title. Use both for exact match.</li>
+			<li><em>in:path</em>, <em>in:title</em>       match only path or title.</li>
+			<li><em>is:event</em>, <em>is:pageview</em>   show only events or pageviews.</li>
+			<li><em>:not</em> negate the match (that is: only show paths that don't match the filter).</li>
+		</ul>
+	</div>"""
 
 ["nav-dash/forced-daily"]
   loc     = ["tpl/dashboard.gohtml:102"]

--- a/i18n/tr-TR.toml
+++ b/i18n/tr-TR.toml
@@ -824,7 +824,18 @@ bana bildirirseniz çok memnun olurum. Bu tamamen isteğe bağlıdır.
   default = "Yolları filtrele"
 
 ["nav-dash/filter-tooltip"]
-  default = "Yolların listesini filtrele; yol ve başlıkta büyük/küçük harfe duyarsız eşleşir"
+  default = """<p>Yolların listesini filtrele; yol ve başlıkta büyük/küçük harfe duyarsız eşleşir. %[%more More help]</p>
+
+	<div>
+		<p>Recognizes the following keywords:</p>
+		<ul>
+			<li><em>at:start</em>, <em>at:end</em>:       match only at the start or end of path or title. Use both for exact match.</li>
+			<li><em>in:path</em>, <em>in:title</em>       match only path or title.</li>
+			<li><em>is:event</em>, <em>is:pageview</em>   show only events or pageviews.</li>
+			<li><em>:not</em> negate the match (that is: only show paths that don't match the filter).</li>
+		</ul>
+	</div>
+  """
 
 ["nav-dash/forced-daily"]
   default = "90 günden uzun bir zaman aralığı için saatlik görünüm kullanılamaz"

--- a/i18n/zh-CN.toml
+++ b/i18n/zh-CN.toml
@@ -824,7 +824,18 @@ Martin
   default = "筛选路径"
 
 ["nav-dash/filter-tooltip"]
-  default = "筛选路径列表；忽略大小写匹配路径和标题"
+  default = """<p>筛选路径列表；忽略大小写匹配路径和标题. %[%more More help]</p>
+
+	<div>
+		<p>Recognizes the following keywords:</p>
+		<ul>
+			<li><em>at:start</em>, <em>at:end</em>:       match only at the start or end of path or title. Use both for exact match.</li>
+			<li><em>in:path</em>, <em>in:title</em>       match only path or title.</li>
+			<li><em>is:event</em>, <em>is:pageview</em>   show only events or pageviews.</li>
+			<li><em>:not</em> negate the match (that is: only show paths that don't match the filter).</li>
+		</ul>
+	</div>
+  """
 
 ["nav-dash/forced-daily"]
   default = "无法对 90 天以上的时间范围应用小时视图"

--- a/public/backend.css
+++ b/public/backend.css
@@ -110,7 +110,6 @@ table.auto { width: auto; }
          max-width: 17.5rem; text-overflow: ellipsis; white-space: nowrap; }
 .rlink { min-width: 3em; } /* Make very short paths (like just /) easier to click/touch. */
 .page-title b, .rlink b { background-color: var(--target-bg); }
-input.value             { background-color: var(--target-bg); }
 
 /* Hide "Go to [..]" link unless we loaded the page details. */
 small.go           { display: none; }
@@ -240,12 +239,7 @@ tr.target .chart-left { display: block; }
              background-color: var(--nav-bg); border-bottom: 1px solid var(--nav-border); border-radius: 2px; }
 #dash-main input[type="text"]     { padding: .3em; }
 #dash-main input[type="checkbox"] { vertical-align: middle; }
-#filter-paths                     { width: 18.5em; display: block; margin-left: auto; }
-#dash-main .date-input            { width: 9em; text-align: center; }
-
-.filter-wrap                 { position: relative; text-align: right; }
-.filter-wrap .loading::after { position: absolute; bottom: 0; right: .5em; }
-
+#dash-main .date-input            { width:9em; text-align:center; }
 #dash-main label { text-align: right; margin-right: .4em; }
 
 #dash-select-period           { display: block; padding-left: .3em; }
@@ -255,20 +249,44 @@ tr.target .chart-left { display: block; }
                   padding: 0 .4em; padding-top: 2px; border-top: 0; margin-top: -4px;
                   border-bottom-left-radius: 2px; border-bottom-right-radius: 2px; }
 
+#filter-outer              { position:relative; }
+#filter-wrap               { position:relative; padding:0; display:flex; width:18.5em;
+                             overflow-x:auto; overflow-y:hidden; scrollbar-width:none; }
+#filter-wrap.value         { outline:3px solid var(--text); }
+#filter-wrap.focus         { outline:1px solid var(--input-focus); box-shadow:0 0 .2em var(--input-focus); }
+#filter-styled             { position:absolute; display:inline-flex; overflow:hidden; user-select:none; -webkit-user-select:none;
+                             padding:.4em; white-space:pre; word-break:break-word; color:var(--text); }
+#filter-outer em           { font-style:normal; color:var(--filter-kw-text); }
+#filter-paths              { min-width:100%; resize:none; z-index:1; flex-shrink:0; margin-left:auto;
+                             background:transparent; color:transparent; caret-color:var(--text); border:0; }
+#filter-paths:focus        { outline:none; box-shadow:none; }
+#filter-paths::placeholder { color:color-mix(in srgb, var(--text) 54%, transparent); }
+#filter-help               { display:none; position:absolute; right:0; z-index:5; padding:0 .3em;
+                             text-align:left; border:1px solid var(--nav-border); border-top:none; background:var(--bg); }
+#filter-help ul            { margin:0; padding-inline-start:20px; }
+#filter-help p             { margin:0; }
+#filter-help div           { margin-top:.75em; display:none; }
+
+/* Text is all off on iOS if we don't do this. This is the styling Safari
+ * applies to <input> and <textarea> */
+@supports (-webkit-overflow-scrolling: touch) {
+    #filter-styled { font-size:16px; line-height:1.3em; }
+}
+
 @media (max-width: 56.5rem) {
     /* Break "current [..]" to new line to make more space. */
-    #dash-select-period span+span { display: block; margin-left: 0em; }
-    #dash-main label              { display: block; }
+    #dash-select-period span+span { display:block; margin-left:0; }
+    #dash-main label              { display:block; }
 }
 
 @media (max-width: 41rem) {
-    #filter-paths  { width: 10em;  }
+    #filter-paths { width:10em;  }
 }
 
 @media (max-width: 33.5rem) {
-    #dash-main       { display: block; }
-    #filter-paths    { width: 100%; margin-top: .5em; }
-    #dash-main label { text-align: left; }
+    #dash-main       { display:block; }
+    #filter-wrap     { width:100%; margin-top:.5em; }
+    #dash-main label { text-align:left; }
 }
 
 .period-day [value=day],

--- a/public/dark.css
+++ b/public/dark.css
@@ -43,6 +43,7 @@
     --nav-bg:            #1b093c;                          /* Navigation at dashboard, settings, and footer */
     --nav-border:        #3f1887;
     --footer-shadow:     #09042e;
+    --filter-kw-text:    #ffff60;                          /* Keyword in filter input (at:start, etc.) */
 
     --info-bg:           #226883;                          /* Flash messages */
     --info-border:       #242683;

--- a/public/shared.css
+++ b/public/shared.css
@@ -63,11 +63,12 @@ form { display: inline; margin: 0; padding: 0; }
 input[type="text"], input[type="search"], input[type="tel"], input[type="url"],
 input[type="email"], input[type="password"], input[type="date"], input[type="month"],
 input[type="week"], input[type="time"], input[type="datetime-local"], input[type="range"],
-input[type="number"], textarea, select {
+input[type="number"], textarea, select, .input {
     font: 1em/100% 'Lato', sans-serif; color: var(--input-text); background-color: var(--input-bg); }
 
 textarea, button:not(.link), select,
-input:not([type="checkbox"]):not([type="file"]):not([type="image"]):not([type="radio"]):not([type="range"]) {
+input:not([type="checkbox"]):not([type="file"]):not([type="image"]):not([type="radio"]):not([type="range"]):not(.unstyled),
+.input {
   padding: .6em;
   border: 1px solid var(--input-border);
   border-radius: 3px; }
@@ -84,7 +85,8 @@ select {
    * it.
   background-color: inherit; */
 }
-input:not(.link):focus,
+input:not(.link):not(.unstyled):focus,
+.input:focus,
 button:not(.link):focus,
 textarea:focus,
 select:focus {

--- a/public/vars.css
+++ b/public/vars.css
@@ -43,6 +43,7 @@
     --nav-bg:            #f8f8d9;                          /* Navigation at dashboard, settings, and footer */
     --nav-border:        #dede89;
     --footer-shadow:     #cdc8a4;
+    --filter-kw-text:    #af5f00;                          /* Keyword in filter input (at:start, etc.) */
 
     --info-bg:           #c9f0ff;                          /* Flash messages */
     --info-border:       #a1a1ff;

--- a/tpl/dashboard.gohtml
+++ b/tpl/dashboard.gohtml
@@ -110,12 +110,27 @@
 		</div>
 
 		<div style="text-align: right">
-			<div class="filter-wrap">
-				<input
-					type="text" autocomplete="off" name="filter" value="{{.View.Filter}}" id="filter-paths"
-					placeholder="{{.T "nav-dash/filter|Filter paths"}}"
-					title="{{.T "nav-dash/filter-tooltip|Filter the list of paths; matched case-insensitive on path and title"}}"
-					{{if .View.Filter}}class="value"{{end}}>
+			<div id="filter-outer">
+				<div id="filter-wrap" class="input{{if .View.Filter}} value{{end}}">
+					<div id="filter-styled" aria-hidden="true"></div>
+					<input
+						type="text" autocomplete="off" name="filter" value="{{.View.Filter}}" id="filter-paths"
+						placeholder="{{.T "nav-dash/filter|Filter paths"}}"
+						class="unstyled">
+				</div>
+				<div id="filter-help">{{.T `nav-dash/filter-tooltip|
+					<p>Filter the list of paths; matched case-insensitive on path and title. %[%more More help]</p>
+
+					<div>
+						<p>Recognizes the following keywords:</p>
+						<ul>
+							<li><em>at:start</em>, <em>at:end</em>:       match only at the start or end of path or title. Use both for exact match.</li>
+							<li><em>in:path</em>, <em>in:title</em>       match only path or title.</li>
+							<li><em>is:event</em>, <em>is:pageview</em>   show only events or pageviews.</li>
+							<li><em>:not</em> negate the match (that is: only show paths that don't match the filter).</li>
+						</ul>
+					</div>
+				` (tag "a" `href="#" id="filter-help-more"`)}}</div>
 			</div>
 			{{/* .T "nav-dash/by-day|View by day" */}}
 


### PR DESCRIPTION
Right now the search field is just a simple "where path like %$1% or title like %$1%". This expands the filter syntax with a few keywords:

    at:start, at:end         match only at the start or end of path or title
    in:path, in:title        match only path or title rather than both
    is:event, is:pageview    show only events or pageviews
    :not                     Negate: "not like" instead of "like" (for entire pattern)

This is pretty basic, but I think this should cover most things. Can be expanded based on demand. Can be expanded based on demand, although one difficulty is making sure the highlights on the frontend are identical to the matching on the backend.


Fixes #194