### PR TITLE
Add language as a field for /api/v0/count

### DIFF
--- a/handlers/api.go
+++ b/handlers/api.go
@@ -625,8 +625,7 @@ func (h api) count(w http.ResponseWriter, r *http.Request) error {
 			if err == nil {
 				base, c := tag.Base()
 				if c == language.Exact || c == language.High {
-					l := base.ISO3()
-					lang = &l
+					lang = new(base.ISO3())
 				}
 			}
 		}

--- a/handlers/api.go
+++ b/handlers/api.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/sethvargo/go-limiter"
+	"golang.org/x/text/language"
 	"zgo.at/errors"
 	"zgo.at/goatcounter/v2"
 	"zgo.at/goatcounter/v2/cron"
@@ -521,6 +522,9 @@ type APICountRequestHit struct {
 	// Location as ISO-3166-1 alpha2 string (e.g. NL, ID, etc.)
 	Location string `json:"location"`
 
+	// Language as a BCP 47 value (e.g. en, en-US, nl, etc.)
+	Language string `json:"language"`
+
 	// IP to get location from; not used if location is set. Also used for
 	// session generation.
 	IP string `json:"ip"`
@@ -549,8 +553,8 @@ type APICountRequestHit struct {
 
 func (h APICountRequestHit) String() string {
 	return fmt.Sprintf(
-		`{Path: %q, Title: %q, Event: %t, Ref: %q, Size: "%s", Query: %q, Bot: %d, UserAgent: %q, Location: %q, IP: %q, CreatedAt: %q, Session: %q, Host: %q}`,
-		h.Path, h.Title, h.Event, h.Ref, h.Size, h.Query, h.Bot, h.UserAgent, h.Location, h.IP, h.CreatedAt, h.Session, h.Host)
+		`{Path: %q, Title: %q, Event: %t, Ref: %q, Size: "%s", Query: %q, Bot: %d, UserAgent: %q, Location: %q, Language: %q, IP: %q, CreatedAt: %q, Session: %q, Host: %q}`,
+		h.Path, h.Title, h.Event, h.Ref, h.Size, h.Query, h.Bot, h.UserAgent, h.Location, h.Language, h.IP, h.CreatedAt, h.Session, h.Host)
 }
 
 // POST /api/v0/count count
@@ -613,6 +617,17 @@ func (h api) count(w http.ResponseWriter, r *http.Request) error {
 			a.Location = (goatcounter.Location{}).LookupIP(r.Context(), a.IP)
 		}
 
+		var lang *string
+		if a.Language != "" && site.Settings.Collect.Has(goatcounter.CollectLanguage) {
+			if tag, err := language.Parse(a.Language); err == nil {
+				base, c := tag.Base()
+				if c == language.Exact || c == language.High {
+					l := base.ISO3()
+					lang = &l
+				}
+			}
+		}
+
 		hit := goatcounter.Hit{
 			Path:            a.Path,
 			Title:           a.Title,
@@ -624,6 +639,7 @@ func (h api) count(w http.ResponseWriter, r *http.Request) error {
 			CreatedAt:       a.CreatedAt.UTC(),
 			UserAgentHeader: a.UserAgent,
 			Location:        a.Location,
+			Language:        lang,
 			RemoteAddr:      a.IP,
 		}
 

--- a/handlers/api.go
+++ b/handlers/api.go
@@ -619,7 +619,10 @@ func (h api) count(w http.ResponseWriter, r *http.Request) error {
 
 		var lang *string
 		if a.Language != "" && site.Settings.Collect.Has(goatcounter.CollectLanguage) {
-			if tag, err := language.Parse(a.Language); err == nil {
+			tag, err := language.Parse(a.Language)
+			// Just silently ignore invalid languages; it's user-provided and
+			// can be set to silly things.
+			if err == nil {
 				base, c := tag.Base()
 				if c == language.Exact || c == language.High {
 					l := base.ISO3()

--- a/handlers/api.go
+++ b/handlers/api.go
@@ -240,7 +240,7 @@ func (h api) auth(r *http.Request, w http.ResponseWriter, require zint.Bitflag64
 }
 
 type apiExportRequest struct {
-	// Export format, defaults to csv. {enum csv json}
+	// Export format, defaults to csv. {enum: csv json}
 	Format string `json:"format"`
 
 	// Pagination cursor for CSV; only export hits with an ID greater than this.

--- a/handlers/api_test.go
+++ b/handlers/api_test.go
@@ -491,6 +491,55 @@ func TestAPICount(t *testing.T) {
 	}
 }
 
+func TestAPICountLanguage(t *testing.T) {
+	tests := []struct {
+		name     string
+		lang     string
+		wantCode int
+		want     string // hits.language value; "NULL" if not set.
+	}{
+		{"plain", "fr", 202, "fra"},
+		{"with-region", "en-US", 202, "eng"},
+		{"empty", "", 202, "NULL"},
+		{"not-well-formed", "klingon", 202, "NULL"},
+		{"well-formed-unknown", "xx", 202, "NULL"},
+	}
+
+	perm := goatcounter.APIPermCount
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := gctest.DB(t)
+			ctx = ztime.WithNow(ctx, ztime.FromString("2020-06-18 14:42:00"))
+
+			site := Site(ctx)
+			site.Settings.Collect.Set(goatcounter.CollectHits)
+			site.Settings.Collect.Set(goatcounter.CollectLanguage)
+			err := site.Update(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			body := APICountRequest{NoSessions: true, Hits: []APICountRequestHit{
+				{Path: "/foo", Language: tt.lang},
+			}}
+			r, rr := newAPITest(ctx, t, "POST", "/api/v0/count",
+				bytes.NewReader(zjson.MustMarshal(body)), perm)
+
+			newBackend(ctx).ServeHTTP(rr, r)
+			ztest.Code(t, rr, tt.wantCode)
+
+			gctest.StoreHits(ctx, t, false)
+
+			have := zdb.DumpString(ctx,
+				`select language from hits`)
+			want := "language\n" + tt.want
+			if d := ztest.Diff(have, want); d != "" {
+				t.Error(d)
+			}
+		})
+	}
+}
+
 func TestAPISitesCreate(t *testing.T) {
 	tests := []struct {
 		serve    bool

--- a/tpl/api.html
+++ b/tpl/api.html
@@ -947,6 +947,8 @@ https://github.com/zgoat/isbot/blob/master/isbot.go#L28</p>
 <p>User-Agent header.</p>
 <h4>location <sup>string</sup></h4>
 <p>Location as ISO-3166-1 alpha2 string (e.g. NL, ID, etc.)</p>
+<h4>language <sup>string</sup></h4>
+<p>Language as a BCP 47 value (e.g. en, en-US, nl, etc.)</p>
 <h4>ip <sup>string</sup></h4>
 <p>IP to get location from; not used if location is set. Also used for
 session generation.</p>
@@ -1003,8 +1005,12 @@ field set, but not both.</p>
 		<h3 id="handlers.apiExportRequest">handlers.apiExportRequest <a class="permalink" href="#handlers.apiExportRequest">§</a></h3>
 		<div class="endpoint model">
 			<p class="info"></p>
-			<h4>start_from_hit_id <sup>integer</sup></h4>
-<p>Pagination cursor; only export hits with an ID greater than this.</p>
+			<h4>format <sup>string [enum: "enum:", "csv", "json"]</sup></h4>
+<p>Export format, defaults to csv.</p>
+<h4>start_from_hit_id <sup>integer</sup></h4>
+<p>Pagination cursor for CSV; only export hits with an ID greater than this.</p>
+<h4>start_from_day <sup>string [format: date-time]</sup></h4>
+<p>The day to start this export from, for JSON exports.</p>
 
 		</div>
 		<h3 id="handlers.apiHitsRequest">handlers.apiHitsRequest <a class="permalink" href="#handlers.apiHitsRequest">§</a></h3>
@@ -1181,10 +1187,14 @@ boundaries.</p>
 <p></p>
 <h4>site_id <sup>integer [readonly]</sup></h4>
 <p></p>
+<h4>format <sup>string [readonly]</sup></h4>
+<p>Export format, csv or json.</p>
 <h4>start_from_hit_id <sup>integer</sup></h4>
-<p>The hit ID this export was started from.</p>
+<p>The hit ID this export was started from, for CSV exports.</p>
 <h4>last_hit_id <sup>integer [readonly]</sup></h4>
 <p>Last hit ID that was exported; can be used as start_from_hit_id.</p>
+<h4>start_from_day <sup>string [format: date-time]</sup></h4>
+<p>The day this export was started from, for JSON exports.</p>
 <h4>created_at <sup>string [format: date-time] [readonly]</sup></h4>
 <p></p>
 <h4>finished_at <sup>string [format: date-time] [readonly]</sup></h4>

--- a/tpl/api.json
+++ b/tpl/api.json
@@ -1475,6 +1475,10 @@
           "description": "IP to get location from; not used if location is set. Also used for\nsession generation.",
           "type": "string"
         },
+        "language": {
+          "description": "Language as a BCP 47 value (e.g. en, en-US, nl, etc.)",
+          "type": "string"
+        },
         "location": {
           "description": "Location as ISO-3166-1 alpha2 string (e.g. NL, ID, etc.)",
           "type": "string"
@@ -1554,8 +1558,22 @@
       "title": "apiExportRequest",
       "type": "object",
       "properties": {
+        "format": {
+          "description": "Export format, defaults to csv.",
+          "type": "string",
+          "enum": [
+            "enum:",
+            "csv",
+            "json"
+          ]
+        },
+        "start_from_day": {
+          "description": "The day to start this export from, for JSON exports.",
+          "type": "string",
+          "format": "date-time"
+        },
         "start_from_hit_id": {
-          "description": "Pagination cursor; only export hits with an ID greater than this.",
+          "description": "Pagination cursor for CSV; only export hits with an ID greater than this.",
           "type": "integer"
         }
       }
@@ -1727,6 +1745,11 @@
           "format": "date-time",
           "readOnly": true
         },
+        "format": {
+          "description": "Export format, csv or json.",
+          "type": "string",
+          "readOnly": true
+        },
         "hash": {
           "description": "SHA256 hash.",
           "type": "string",
@@ -1754,8 +1777,13 @@
           "type": "string",
           "readOnly": true
         },
+        "start_from_day": {
+          "description": "The day this export was started from, for JSON exports.",
+          "type": "string",
+          "format": "date-time"
+        },
         "start_from_hit_id": {
-          "description": "The hit ID this export was started from.",
+          "description": "The hit ID this export was started from, for CSV exports.",
           "type": "integer"
         }
       }


### PR DESCRIPTION
We expect a BCP 47 string, as it is easier to get from a browser with `navigator.language` (unlike ISO 639-3). If we wanted to extend this change to the CSV import/export, we would need to accept both, which should be easy enough as it is easy to distinguish them.

This is similar to what was done in #535.
