### PR TITLE
Send pageviews on first interaction, rather than page load

### DIFF
--- a/public/count.js
+++ b/public/count.js
@@ -248,8 +248,8 @@
 
 	if (!goatcounter.no_onload)
 		on_load(function() {
+			var sent = false // Make sure it triggers only one of below events.
 			['touchmove', 'mousemove', 'keydown', 'pointerdown'].forEach(function(n) {
-				var sent = false
 				var bind = function() {
 					document.removeEventListener(n, bind)
 					if (sent)

--- a/public/count.js
+++ b/public/count.js
@@ -248,20 +248,17 @@
 
 	if (!goatcounter.no_onload)
 		on_load(function() {
-			// 1. Page is visible, count request.
-			// 2. Page is not yet visible; wait until it switches to 'visible' and count.
-			// See #487
-			if (!('visibilityState' in document) || document.visibilityState === 'visible')
-				goatcounter.count()
-			else {
-				var f = function(e) {
-					if (document.visibilityState !== 'visible')
+			['touchmove', 'mousemove', 'keydown', 'pointerdown'].forEach(function(n) {
+				var sent = false
+				var bind = function() {
+					document.removeEventListener(n, bind)
+					if (sent)
 						return
-					document.removeEventListener('visibilitychange', f)
+					sent = true
 					goatcounter.count()
 				}
-				document.addEventListener('visibilitychange', f)
-			}
+				document.addEventListener(n, bind)
+			})
 
 			if (!goatcounter.no_events)
 				goatcounter.bind_events()

--- a/tpl/help/countjs-versions.md
+++ b/tpl/help/countjs-versions.md
@@ -10,6 +10,10 @@ but you may need to update it in the future for new features.
 Latest
 ------
 
+- Pageviews are now sent on the first interaction (mouse move, touch screen
+  press, key press) rather than on page load, which should reduce pageviews from
+  bots.
+
 - Only send screen width (instead of width, height, and devicePixelRatio).
 
 - Check for existence of `navigator.sendBeacon()`, and use the image-based


### PR DESCRIPTION
This is what Bear Blog does apparently. Seems like a good idea.

I *think* we can remove the visibilityState code now? Not entirely sure actually. Only did a quick test – want to test a bit more.

Copied via
https://github.com/vincentbernat/vincent.bernat.ch/blob/latest/content/media/js/luffy.00-analytics.js