### PR TITLE
Add a proxy to forward page counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ to 18, which means you'll have to do a dump/restore or use pg_upgrade.
 
 - Add language as a field for `/api/v0/count`.
 
+- Add a `goatcounter proxy` command: a lightweight collector that exposes only
+  the `/count` endpoint and batches/forwards pageviews to another GoatCounter
+  server's `/api/v0/count` API. The batch size and the minimum and maximum time
+  to wait before sending a batch are configurable.
+
 ### Fixes
 
 - Improve performance of filter with a large amount (100,000s) of paths.

--- a/cmd/goatcounter/help.go
+++ b/cmd/goatcounter/help.go
@@ -29,7 +29,7 @@ func cmdHelp(f zli.Flags, ready chan<- struct{}, stop chan struct{}) error {
 			continue
 		}
 		if a == "all" {
-			topics = []string{"help", "version", "serve", "import",
+			topics = []string{"help", "version", "serve", "import", "proxy",
 				"dashboard", "db", "monitor", "listen", "logfile", "log", "debug"}
 			break
 		}
@@ -70,6 +70,7 @@ var usage = map[string]string{
 	"saas":      usageSaas,
 	"monitor":   usageMonitor,
 	"import":    usageImport,
+	"proxy":     usageProxy,
 	"dashboard": usageDashboard,
 	"db":        helpDB,
 	"listen":    helpListen,
@@ -97,6 +98,7 @@ Commands:
   version      Show version and build information and exit.
   serve        Start HTTP server.
   import       Import pageviews from an export or logfile.
+  proxy        Proxy and batch /count requests to another GoatCounter server.
 
   dashboard    Show dashboard statistics in the terminal.
   db           Modify the database and print database info.
@@ -240,6 +242,7 @@ commas.
     memstore       Storing of pageviews in the database
     migrate        Database migrations
     monitor        Additional logs in "goatcounter monitor"
+    proxy          Forwarding of pageviews in "goatcounter proxy"
     refspam        Pageviews blocked due to being in the refspam list
     req            HTTP requests (all except /count, /api/v0/count, and /loader)
     session        Internal "session" generation to track visitors

--- a/cmd/goatcounter/main.go
+++ b/cmd/goatcounter/main.go
@@ -59,7 +59,7 @@ func cmdMain(f zli.Flags, ready chan<- struct{}, stop chan struct{}) {
 	mainDone.Add(1)
 	defer mainDone.Done()
 
-	cmd, err := f.ShiftCommand("help", "version", "serve", "import",
+	cmd, err := f.ShiftCommand("help", "version", "serve", "import", "proxy",
 		"dashboard", "db", "monitor",
 		"saas", "goat")
 	if zslice.ContainsAny(f.Args, "-h", "-help", "--help") {
@@ -127,6 +127,8 @@ func cmdMain(f zli.Flags, ready chan<- struct{}, stop chan struct{}) {
 		run = cmdMonitor
 	case "import":
 		run = cmdImport
+	case "proxy":
+		run = cmdProxy
 	case "dashboard":
 		// Wrap as this also doubles as an example, and these flags just obscure
 		// things.

--- a/cmd/goatcounter/proxy.go
+++ b/cmd/goatcounter/proxy.go
@@ -169,10 +169,6 @@ func cmdProxy(f zli.Flags, ready chan<- struct{}, stop chan struct{}) error {
 		return err
 	}
 
-	if err := checkSite(site, key, goatcounter.APIPermCount); err != nil {
-		return err
-	}
-
 	p := &proxy{
 		url:      site,
 		key:      key,

--- a/cmd/goatcounter/proxy.go
+++ b/cmd/goatcounter/proxy.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"os"
 	"strconv"
@@ -436,13 +435,6 @@ func (p *proxy) count(w http.ResponseWriter, r *http.Request) error {
 		w.Header().Add("X-Goatcounter", fmt.Sprintf("wrong value: b=%d", hit.Bot))
 		w.WriteHeader(400)
 		return zhttp.Bytes(w, gif)
-	}
-	for _, s := range hit.Size {
-		if s > math.MaxInt32 {
-			w.Header().Add("X-Goatcounter", fmt.Sprintf("ignored because screen size %v is out of range of int32", s))
-			w.WriteHeader(400)
-			return zhttp.Bytes(w, gif)
-		}
 	}
 	if isbot.Is(bot) { // Prefer the backend detection.
 		hit.Bot = int(bot)

--- a/cmd/goatcounter/proxy.go
+++ b/cmd/goatcounter/proxy.go
@@ -1,0 +1,752 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/monoculum/formam/v3"
+	"github.com/sethvargo/go-limiter"
+	"github.com/sethvargo/go-limiter/memorystore"
+	"golang.org/x/text/language"
+	"zgo.at/errors"
+	"zgo.at/goatcounter/v2"
+	"zgo.at/goatcounter/v2/handlers"
+	"zgo.at/goatcounter/v2/pkg/log"
+	"zgo.at/isbot"
+	"zgo.at/json"
+	"zgo.at/z18n"
+	"zgo.at/zhttp"
+	"zgo.at/zhttp/mware"
+	"zgo.at/zli"
+	"zgo.at/zstd/zstring"
+)
+
+const usageProxy = `
+Run a proxy for the /count endpoint.
+
+Overview:
+
+  The proxy exposes only the /count endpoint that the GoatCounter tracking
+  script (and the navigator.sendBeacon API) talk to. It collects pageviews in
+  memory, batches them, and forwards them to a "real" GoatCounter server using
+  the /api/v0/count API.
+
+  It needs a running GoatCounter server to forward to, and an API key with
+  "Record pageviews" permissions set in GOATCOUNTER_API_KEY:
+
+      $ export GOATCOUNTER_API_KEY=[..]
+      $ goatcounter proxy -site=https://stats.example.com
+
+  All pageviews are forwarded to the single site the API key belongs to.
+
+  Pageviews are not forwarded immediately, but collected and sent in batches.
+  A batch is flushed when any of these happens, whichever comes first:
+
+    - it reaches -batch pageviews,
+    - -batch-max-time elapses since the oldest waiting pageview came in, or
+    - -batch-min-time elapses without any new pageview coming in.
+
+  If the upstream server can't be reached, or answers with a temporary error
+  such as "503 no backend available", the batch is kept and retried. The wait
+  between retries doubles up to a minute, and the proxy keeps trying for as long
+  as the server stays down. Pageviews that come in meanwhile are queued, up to
+  -queue of them. Past that the oldest ones are dropped.
+
+  A batch is only given up on when the upstream server says the request itself
+  is the problem (any 4xx other than 429).
+
+Environment:
+
+  All of the flags take the defaults from $GOATCOUNTER_«FLAG», where «FLAG» is
+  the flag name. The commandline flag will override the environment variable.
+
+  Additional environment variables:
+
+    GOATCOUNTER_API_KEY   API key; requires "Record pageviews" permission.
+
+Flags:
+
+  -listen      Address to listen on. Default: "*:8080". See "goatcounter help
+               listen" for detailed documentation.
+
+  -site        Site to forward to, as an URL (e.g. "https://stats.example.com")
+
+  -batch       Maximum number of pageviews to send in one batch; capped at 500,
+               which is the maximum the API accepts. Default: 100.
+
+  -queue       Maximum number of pageviews to keep in memory while they wait to
+               be forwarded.
+
+               One pageview needs roughly 600 bytes, so a full queue needs about
+               60M at the default. Default: 100000.
+
+  -batch-min-time
+               Minimum time to wait before sending a batch: a batch is sent once
+               no new pageview has come in for this long. Accepts a Go duration
+               such as "500ms", "2s", or "1m". Default: 1s.
+
+  -batch-max-time
+               Maximum time to wait before sending a batch: a pageview is never
+               held longer than this. Accepts a Go duration. Default: 15s.
+
+  -ratelimit   Rate limit for the /count endpoint, as "requests/seconds"; the
+               limit is applied per client (IP + User-Agent). Use "off" to
+               disable. Default: 4/1 (4 requests per second).
+
+  -debug       Modules to debug, comma-separated or 'all' for all modules.
+               See "goatcounter help debug" for a list of modules.
+
+  -json        Output logs as JSON instead of aligned text.
+`
+
+func cmdProxy(f zli.Flags, ready chan<- struct{}, stop chan struct{}) error {
+	var (
+		debugFlag = f.StringList(nil, "debug")
+		jsonFlag  = f.Bool(false, "json")
+		listen    = f.String(":8080", "listen")
+		siteFlag  = f.String("", "site")
+		batch     = f.Int(100, "batch")
+		queue     = f.Int(100_000, "queue")
+		batchMin  = f.String("1s", "batch-min-time")
+		batchMax  = f.String("15s", "batch-max-time")
+		ratelimit = f.String("4/1", "ratelimit")
+	)
+	if err := f.Parse(zli.FromEnv("GOATCOUNTER")); err != nil && !errors.As(err, &zli.ErrUnknownEnv{}) {
+		return err
+	}
+
+	setupLog(false, jsonFlag.Bool(), debugFlag.StringsSplit(","))
+
+	site := strings.TrimRight(siteFlag.String(), "/")
+	if site == "" {
+		return errors.New("-site must be set")
+	}
+	if !zstring.HasPrefixes(site, "http://", "https://") {
+		site = "https://" + site
+	}
+
+	key := os.Getenv("GOATCOUNTER_API_KEY")
+	if key == "" {
+		return errors.New("GOATCOUNTER_API_KEY must be set")
+	}
+
+	if batch.Int() < 1 {
+		return errors.New("-batch must be at least 1")
+	}
+	if batch.Int() > 500 {
+		*batch.Pointer() = 500
+	}
+	if queue.Int() < batch.Int() {
+		return fmt.Errorf("-queue (%d) can't be smaller than -batch (%d)", queue.Int(), batch.Int())
+	}
+
+	minWait, err := time.ParseDuration(batchMin.String())
+	if err != nil {
+		return fmt.Errorf("-batch-min-time: %w", err)
+	}
+	maxWait, err := time.ParseDuration(batchMax.String())
+	if err != nil {
+		return fmt.Errorf("-batch-max-time: %w", err)
+	}
+	if minWait <= 0 || maxWait <= 0 {
+		return errors.New("-batch-min-time and -batch-max-time must be positive")
+	}
+	if minWait > maxWait {
+		return errors.New("-batch-min-time can't be larger than -batch-max-time")
+	}
+
+	rlStore, err := proxyRatelimit(ratelimit.String())
+	if err != nil {
+		return err
+	}
+
+	if err := checkSite(site, key, goatcounter.APIPermCount); err != nil {
+		return err
+	}
+
+	p := &proxy{
+		url:      site,
+		key:      key,
+		maxBatch: batch.Int(),
+		minWait:  minWait,
+		maxWait:  maxWait,
+		queue:    newHitQueue(queue.Int()),
+		in:       make(chan handlers.APICountRequestHit, min(queue.Int(), hitQueueMin)),
+		want:     make(chan struct{}),
+		batches:  make(chan []handlers.APICountRequestHit, 1),
+	}
+
+	// The batcher has its own stop channel rather than reusing the server's:
+	// zhttp.Serve consumes `stop` (and handles OS signals) itself, so we only
+	// stop the batcher once the server has shut down and no more pageviews can
+	// come in.
+	batcherStop := make(chan struct{})
+	batcherDone := make(chan struct{})
+	go p.run(batcherStop, batcherDone)
+
+	r := chi.NewRouter()
+	r.Use(mware.RealIP(), mware.WrapWriter())
+	var rr chi.Router = r
+	if rlStore != nil {
+		rr = r.With(handlers.Ratelimit(true, func(*http.Request) ([]limiter.Store, string) {
+			return []limiter.Store{rlStore}, ""
+		}))
+	}
+	rr.Get("/count", zhttp.Wrap(p.count))
+	rr.Post("/count", zhttp.Wrap(p.count)) // to support navigator.sendBeacon (JS)
+
+	ch, err := zhttp.Serve(0, stop, &http.Server{
+		Addr:    listen.String(),
+		Handler: r,
+	})
+	if err != nil {
+		return err
+	}
+
+	<-ch // Server is set up.
+	log.Module("startup").Info(context.Background(), "GoatCounter proxy ready",
+		"listen", listen.String(), "site", site,
+		"batch", p.maxBatch, "batch_min", minWait.String(), "batch_max", maxWait.String(),
+		"queue", queue.Int())
+	ready <- struct{}{}
+
+	<-ch // Server is shut down; no more pageviews will come in.
+
+	// Tell the batcher to flush whatever is left and wait for it.
+	close(batcherStop)
+	<-batcherDone
+	return nil
+}
+
+// proxyRatelimit builds the rate-limit store for the /count endpoint from a
+// "requests/seconds" spec. A value of "off" (or empty) returns a nil store,
+// which disables rate limiting.
+func proxyRatelimit(spec string) (limiter.Store, error) {
+	if spec == "" || strings.EqualFold(spec, "off") {
+		return nil, nil
+	}
+
+	reqs, secs, ok := strings.Cut(spec, "/")
+	if !ok {
+		return nil, fmt.Errorf("-ratelimit: must be as requests/seconds, e.g. 4/1")
+	}
+	r, err := strconv.Atoi(reqs)
+	if err != nil || r < 1 {
+		return nil, fmt.Errorf("-ratelimit: invalid number of requests: %q", reqs)
+	}
+	s, err := strconv.Atoi(secs)
+	if err != nil || s < 1 {
+		return nil, fmt.Errorf("-ratelimit: invalid number of seconds: %q", secs)
+	}
+
+	store, err := memorystore.New(&memorystore.Config{
+		Tokens:   uint64(r),
+		Interval: time.Duration(s) * time.Second,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+// proxy collects pageviews from /count requests, batches them, and forwards
+// them to a GoatCounter server's /api/v0/count endpoint.
+//
+// The work is split over three stages, each owning its own data and talking to
+// the next one over channels only:
+//
+//  1. Receiving: the /count handlers, one goroutine per request as usual for
+//     net/http. They parse the pageview and put it on p.in, and do nothing else,
+//     so a slow or unreachable upstream server never delays a response.
+//
+//  2. Keeping: a single goroutine (run) that owns the queue of the last -queue
+//     pageviews and decides when a batch is ready. It never does any I/O, so it
+//     always keeps up with stage 1.
+//
+//  3. Forwarding: a single goroutine (forward) that asks stage 2 for a batch,
+//     sends it upstream, and retries for as long as that takes. It handles one
+//     batch at a time, which keeps them in order and means a batch being
+//     retried can't overtake the next one.
+type proxy struct {
+	url, key string
+	maxBatch int
+	minWait  time.Duration
+	maxWait  time.Duration
+
+	in      chan handlers.APICountRequestHit   // Stage 1 -> 2: one pageview.
+	batches chan []handlers.APICountRequestHit // Stage 2 -> 3: the batch, nil when there's no more.
+	want    chan struct{}                      // Stage 3 -> 2: ready for a batch.
+	queue   *hitQueue                          // Owned by stage 2.
+}
+
+const (
+	// Smallest the ring buffer ever gets: what it starts at, and what it goes
+	// back down to once a backlog has cleared.
+	hitQueueMin = 1024
+
+	// How often to report that the queue is full and pageviews are being lost.
+	dropLogInterval = time.Minute
+)
+
+// hitQueue holds the pageviews that are waiting to be forwarded, in a ring
+// buffer with an upper bound on its size. Adding to a full queue overwrites the
+// oldest pageview instead of growing further: if the upstream server is down for
+// hours we can't keep everything, and the recent pageviews are the ones worth
+// keeping.
+//
+// The ring starts at hitQueueMin and doubles as needed, so a large -queue only
+// costs memory once there really is a backlog, and halves again as the backlog
+// clears, so that memory is given back afterwards.
+//
+// It has no locking of its own: only the stage 2 goroutine touches it.
+type hitQueue struct {
+	max     int // Never hold more than this many pageviews.
+	buf     []handlers.APICountRequestHit
+	head    int       // Position of the oldest pageview in buf.
+	n       int       // Number of pageviews in buf.
+	dropped int64     // Total overwritten because the queue was full.
+	lastLog time.Time // When we last reported dropping pageviews.
+}
+
+func newHitQueue(max int) *hitQueue {
+	return &hitQueue{
+		max: max,
+		buf: make([]handlers.APICountRequestHit, min(max, hitQueueMin)),
+	}
+}
+
+// push adds a pageview, overwriting the oldest one if the queue is full.
+func (q *hitQueue) push(ctx context.Context, h handlers.APICountRequestHit) {
+	if q.n == len(q.buf) && q.n < q.max {
+		q.grow()
+	}
+	if q.n == len(q.buf) {
+		// Full: overwrite the oldest pageview and move the head along.
+		q.buf[q.head] = h
+		q.head = (q.head + 1) % len(q.buf)
+		q.dropped++
+
+		if now := time.Now(); now.Sub(q.lastLog) >= dropLogInterval {
+			q.lastLog = now
+			log.Module("proxy").Warnf(ctx, "queue of %d pageviews is full; dropped %d pageviews so far",
+				q.max, q.dropped)
+		}
+		return
+	}
+
+	q.buf[(q.head+q.n)%len(q.buf)] = h
+	q.n++
+}
+
+// grow doubles the ring, up to max.
+func (q *hitQueue) grow() {
+	q.resize(min(2*len(q.buf), q.max))
+}
+
+// shrink halves the ring, as many times as it can, so that the memory claimed
+// during a backlog is given back once that backlog has cleared.
+func (q *hitQueue) shrink() {
+	size := len(q.buf)
+	for size/2 >= hitQueueMin && q.n <= size/4 {
+		size /= 2
+	}
+	if size < len(q.buf) {
+		q.resize(size)
+	}
+}
+
+// resize moves the pageviews into a buffer of a different size. They go to the
+// start of it, so the oldest one is back at position zero.
+func (q *hitQueue) resize(size int) {
+	buf := make([]handlers.APICountRequestHit, size)
+	for i := range q.n {
+		buf[i] = q.buf[(q.head+i)%len(q.buf)]
+	}
+	q.buf, q.head = buf, 0
+}
+
+// pop removes and returns up to max pageviews, oldest first.
+func (q *hitQueue) pop(max int) []handlers.APICountRequestHit {
+	if q.n == 0 {
+		return nil
+	}
+	n := min(max, q.n)
+	batch := make([]handlers.APICountRequestHit, n)
+	for i := range n {
+		p := (q.head + i) % len(q.buf)
+		batch[i] = q.buf[p]
+		q.buf[p] = handlers.APICountRequestHit{}
+	}
+	q.head = (q.head + n) % len(q.buf)
+	q.n -= n
+	q.shrink()
+	return batch
+}
+
+// oldest returns when the oldest waiting pageview came in, and false if the
+// queue is empty.
+func (q *hitQueue) oldest() (time.Time, bool) {
+	if q.n == 0 {
+		return time.Time{}, false
+	}
+	return q.buf[q.head].CreatedAt, true
+}
+
+// Use GIF because it's the smallest filesize (PNG is 116 bytes, vs 43 for GIF).
+var gif = []byte{0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x1, 0x0, 0x1, 0x0, 0x80,
+	0x1, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0xff, 0x21, 0xf9, 0x4, 0x1, 0xa, 0x0,
+	0x1, 0x0, 0x2c, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x1, 0x0, 0x0, 0x2, 0x2, 0x4c,
+	0x1, 0x0, 0x3b}
+
+// count handles a /count request: it parses the pageview from the query string
+// like the regular /count endpoint does, and queues it for forwarding.
+func (p *proxy) count(w http.ResponseWriter, r *http.Request) error {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Content-Type", "image/gif")
+	w.Header().Set("Cross-Origin-Resource-Policy", "cross-origin")
+	w.Header().Set("Connection", "close")
+
+	bot := isbot.Bot(r)
+	if bot == isbot.BotPrefetch {
+		return zhttp.Bytes(w, gif)
+	}
+
+	// Site is not known here: the API key decides which site the pageview ends
+	// up on. Validate only checks that the field is set.
+	hit := goatcounter.Hit{
+		Site:            1,
+		UserAgentHeader: r.UserAgent(),
+		CreatedAt:       time.Now().UTC(),
+	}
+	err := formam.NewDecoder(&formam.DecoderOptions{
+		TagName:           "json",
+		IgnoreUnknownKeys: true,
+	}).Decode(r.URL.Query(), &hit)
+	if err != nil {
+		w.Header().Add("X-Goatcounter", fmt.Sprintf("error decoding parameters: %s", err))
+		w.WriteHeader(400)
+		return zhttp.Bytes(w, gif)
+	}
+	if hit.Bot > 0 && hit.Bot < 150 {
+		w.Header().Add("X-Goatcounter", fmt.Sprintf("wrong value: b=%d", hit.Bot))
+		w.WriteHeader(400)
+		return zhttp.Bytes(w, gif)
+	}
+	for _, s := range hit.Size {
+		if s > math.MaxInt32 {
+			w.Header().Add("X-Goatcounter", fmt.Sprintf("ignored because screen size %v is out of range of int32", s))
+			w.WriteHeader(400)
+			return zhttp.Bytes(w, gif)
+		}
+	}
+	if isbot.Is(bot) { // Prefer the backend detection.
+		hit.Bot = int(bot)
+	}
+
+	err = hit.Validate(z18n.With(r.Context(), goatcounter.DefaultLocale), true)
+	if err != nil {
+		w.Header().Add("X-Goatcounter", fmt.Sprintf("not valid: %s", err))
+		w.WriteHeader(400)
+		return zhttp.Bytes(w, gif)
+	}
+
+	a := handlers.APICountRequestHit{
+		Path:      hit.Path,
+		Title:     hit.Title,
+		Event:     hit.Event,
+		Ref:       hit.Ref,
+		Size:      hit.Size,
+		Query:     hit.Query,
+		Bot:       hit.Bot,
+		UserAgent: hit.UserAgentHeader,
+		IP:        r.RemoteAddr,
+		CreatedAt: hit.CreatedAt,
+	}
+	// Forward the preferred language as BCP 47; the central server decides
+	// whether to record it based on its own "Collect" settings.
+	if tags, _, _ := language.ParseAcceptLanguage(r.Header.Get("Accept-Language")); len(tags) > 0 {
+		a.Language = tags[0].String()
+	}
+
+	// Hand over to stage 2 and get out of the way. This only ever waits for
+	// another goroutine to copy a value, never for the upstream server.
+	p.in <- a
+	return zhttp.Bytes(w, gif)
+}
+
+// How long to keep retrying after the HTTP server has stopped, before giving
+// up on the pageviews that are still waiting.
+const shutdownGrace = 5 * time.Second
+
+// run is stage 2: it owns the queue, takes pageviews from the /count handlers,
+// and hands a batch to the forwarding goroutine whenever that one asks for
+// work and there's a batch worth sending.
+//
+// A batch is ready when it holds -batch pageviews, when -batch-max-time has
+// passed since the oldest waiting pageview came in, or when -batch-min-time has
+// passed without any new pageview.
+//
+// It returns (closing done) once stop is closed and everything left in the
+// queue has been forwarded, or given up on.
+func (p *proxy) run(stop <-chan struct{}, done chan<- struct{}) {
+	defer close(done)
+
+	ctx := context.Background()
+
+	// Start forwarding goroutine. When stopping this one, allows a few seconds
+	// for the forwarding gorouting to stop.
+	sendStop := make(chan struct{})
+	forwardDone := make(chan struct{})
+	go func() {
+		<-stop
+		time.Sleep(shutdownGrace)
+		close(sendStop)
+	}()
+	go p.forward(sendStop, forwardDone)
+
+	var (
+		pending  bool // The forwarder is waiting for a batch.
+		flush    bool // A timer went off: hand over what we have.
+		minTimer = stoppedTimer()
+		maxTimer = stoppedTimer()
+	)
+	for {
+		if pending && p.queue.n > 0 && (flush || p.queue.n >= p.maxBatch) {
+			p.batches <- p.queue.pop(p.maxBatch)
+			pending, flush = false, false
+
+			minTimer.Stop()
+			maxTimer.Stop()
+			// Anything left over has been waiting since before this batch, so
+			// take that off its -batch-max-time.
+			if oldest, ok := p.queue.oldest(); ok {
+				minTimer.Reset(p.minWait)
+				maxTimer.Reset(max(0, p.maxWait-time.Since(oldest)))
+			}
+			continue
+		}
+
+		select {
+		case h := <-p.in:
+			if p.queue.n == 0 { // First of a new batch: start the clock.
+				maxTimer.Reset(p.maxWait)
+				flush = false
+			}
+			minTimer.Reset(p.minWait) // Wait for a quiet period again.
+			p.queue.push(ctx, h)
+		case <-p.want:
+			pending = true
+		case <-minTimer.C:
+			flush = true
+		case <-maxTimer.C:
+			flush = true
+		case <-stop:
+			p.drain(ctx, pending, forwardDone)
+			if p.queue.dropped > 0 {
+				log.Module("proxy").Warnf(ctx, "dropped %d pageviews because the queue was full",
+					p.queue.dropped)
+			}
+			return
+		}
+	}
+}
+
+// drain forwards whatever is left once the HTTP server has stopped and no new
+// pageviews can come in, and then waits for the forwarding goroutine to finish.
+func (p *proxy) drain(ctx context.Context, pending bool, forwardDone <-chan struct{}) {
+	for {
+		// Pick up anything the handlers left behind.
+		for done := false; !done; {
+			select {
+			case h := <-p.in:
+				p.queue.push(ctx, h)
+			default:
+				done = true
+			}
+		}
+
+		if !pending {
+			<-p.want
+		}
+		batch := p.queue.pop(p.maxBatch)
+		p.batches <- batch // A nil batch tells the forwarder to stop.
+		if batch == nil {
+			<-forwardDone
+			return
+		}
+		pending = false
+	}
+}
+
+// stoppedTimer returns a stopped timer that can be (re)started with Reset.
+func stoppedTimer() *time.Timer {
+	t := time.NewTimer(time.Hour)
+	t.Stop()
+	return t
+}
+
+// forward is stage 3: it asks the queue for a batch, sends it upstream, and
+// only comes back for the next one when it's done. It returns (closing done)
+// when the queue says there's nothing left.
+func (p *proxy) forward(stop <-chan struct{}, done chan<- struct{}) {
+	defer close(done)
+
+	for {
+		p.want <- struct{}{}
+		batch := <-p.batches
+		if batch == nil {
+			return
+		}
+		p.send(batch, stop)
+	}
+}
+
+var proxyClient = http.Client{Timeout: 10 * time.Second}
+
+const (
+	// Upper bound for the wait between two retries.
+	maxRetryWait = time.Minute
+
+	// Upper bound for how long we believe an upstream server that asks us to
+	// slow down.
+	maxRateLimitWait = 5 * time.Minute
+)
+
+// sendResult says what to do with a batch after trying to forward it.
+type sendResult int
+
+const (
+	sendOK    sendResult = iota // Accepted by the upstream server.
+	sendRetry                   // Temporary problem; the same batch can be sent again.
+	sendDrop                    // The batch or our configuration is wrong; sending it again won't help.
+)
+
+// send forwards a batch of pageviews to the upstream server's /api/v0/count
+// endpoint. It keeps retrying as long as the problem looks temporary, so an
+// outage of any length is survivable; it only gives up when stop is closed, or
+// when the upstream server says the batch itself is the problem.
+func (p *proxy) send(hits []handlers.APICountRequestHit, stop <-chan struct{}) {
+	ctx := context.Background()
+
+	body, err := json.Marshal(handlers.APICountRequest{Hits: hits})
+	if err != nil {
+		log.Module("proxy").Error(ctx, err)
+		return
+	}
+
+	for attempt := 0; ; attempt++ {
+		result, wait, reason := p.post(ctx, body, len(hits))
+		switch result {
+		case sendOK:
+			if attempt > 0 {
+				log.Module("proxy").Infof(ctx, "%s is back; forwarded %d pageviews after %d retries",
+					p.url, len(hits), attempt)
+			}
+			return
+		case sendDrop:
+			log.Module("proxy").Warnf(ctx, "dropping %d pageviews: %s", len(hits), reason)
+			return
+		}
+
+		if wait <= 0 {
+			wait = retryWait(attempt)
+		}
+		if attempt == 0 { // Only report the first failure; the rest is noise.
+			log.Module("proxy").Warnf(ctx, "can't forward %d pageviews, retrying until it works: %s",
+				len(hits), reason)
+		} else {
+			log.Module("proxy").Debugf(ctx, "retry %d for %d pageviews in %s: %s",
+				attempt, len(hits), wait, reason)
+		}
+
+		t := time.NewTimer(wait)
+		select {
+		case <-t.C:
+		case <-stop:
+			t.Stop()
+			log.Module("proxy").Warnf(ctx, "shutting down while %s is unreachable: dropped %d pageviews",
+				p.url, len(hits))
+			return
+		}
+	}
+}
+
+// post sends one batch and reports what to do next. The returned duration is
+// how long the upstream server asked us to wait, and is zero if it didn't ask
+// for anything in particular.
+func (p *proxy) post(ctx context.Context, body []byte, n int) (sendResult, time.Duration, error) {
+	r, err := newRequest("POST", p.url+"/api/v0/count", p.key, bytes.NewReader(body))
+	if err != nil {
+		return sendDrop, 0, err
+	}
+
+	log.Module("proxy").Debugf(ctx, "POST %s with %d pageviews", p.url, n)
+	resp, err := proxyClient.Do(r)
+	if err != nil {
+		// Connection refused, DNS failure, timeout: the server should come back.
+		return sendRetry, 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 200 || resp.StatusCode == 202 {
+		io.Copy(io.Discard, resp.Body) // Read to the end so the connection can be reused.
+		return sendOK, 0, nil
+	}
+
+	b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	reason := fmt.Errorf("%s: %s: %s", p.url+"/api/v0/count", resp.Status,
+		zstring.ElideLeft(strings.TrimSpace(string(b)), 500))
+
+	switch {
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return sendRetry, retryAfter(resp.Header), reason
+	case retryableStatus(resp.StatusCode):
+		return sendRetry, 0, reason
+	default:
+		return sendDrop, 0, reason
+	}
+}
+
+// retryableStatus reports whether it's worth sending the same batch again after
+// this status code.
+//
+// A 5xx means the upstream server, or a proxy in front of it, is having trouble
+// ("no backend available" and such) and should come back later. A 4xx means the
+// request is not acceptable and repeating it gets the same answer, so the batch
+// is given up on; that also covers a wrong -site or a revoked API key. The
+// exceptions are 429, handled by the caller, and the two codes that report a
+// timing problem rather than a bad request.
+func retryableStatus(code int) bool {
+	switch code {
+	case http.StatusRequestTimeout, http.StatusTooEarly:
+		return true
+	}
+	return code >= 500
+}
+
+// retryAfter reads how long the upstream server wants us to wait, in seconds.
+// It returns zero if there's no usable value, and the caller then falls back to
+// its own backoff.
+func retryAfter(h http.Header) time.Duration {
+	for _, k := range []string{"X-Rate-Limit-Reset", "Retry-After"} {
+		if s, err := strconv.Atoi(h.Get(k)); err == nil && s > 0 {
+			return min(time.Duration(s)*time.Second, maxRateLimitWait)
+		}
+	}
+	return 0
+}
+
+// retryWait returns how long to wait before retry number n: it starts at a
+// second and doubles every time, up to maxRetryWait.
+func retryWait(n int) time.Duration {
+	return min(time.Second<<min(n, 10), maxRetryWait)
+}

--- a/cmd/goatcounter/proxy_test.go
+++ b/cmd/goatcounter/proxy_test.go
@@ -16,10 +16,9 @@ import (
 	"zgo.at/zli"
 )
 
-// upstream is a minimal GoatCounter server that only implements the two
-// endpoints the proxy talks to: /api/v0/me (for checkSite) and /api/v0/count.
-// The reply to /api/v0/count can be changed while the test runs, to act like a
-// server that is down for a while.
+// upstream is a minimal GoatCounter server that only implements /api/v0/count,
+// the one endpoint the proxy talks to. Its reply can be changed while the test
+// runs, to act like a server that is down for a while.
 type upstream struct {
 	*httptest.Server
 
@@ -35,35 +34,32 @@ func newUpstream(t *testing.T) *upstream {
 
 	u := new(upstream)
 	u.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/api/v0/me":
-			// permissions=2 is APIPermCount.
-			fmt.Fprint(w, `{"token":{"name":"test","permissions":2}}`)
-		case "/api/v0/count":
-			var req handlers.APICountRequest
-			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-				t.Errorf("decode count request: %s", err)
-				w.WriteHeader(400)
-				return
-			}
-
-			u.mu.Lock()
-			defer u.mu.Unlock()
-			u.posts++
-			if u.status != 0 {
-				if u.resetHdr != "" {
-					w.Header().Set("X-Rate-Limit-Reset", u.resetHdr)
-				}
-				w.WriteHeader(u.status)
-				fmt.Fprint(w, `{"error":"nope"}`)
-				return
-			}
-			u.got = append(u.got, req.Hits...)
-			w.WriteHeader(http.StatusAccepted)
-		default:
+		if r.URL.Path != "/api/v0/count" {
 			t.Errorf("unexpected request to %s", r.URL.Path)
 			w.WriteHeader(404)
+			return
 		}
+
+		var req handlers.APICountRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode count request: %s", err)
+			w.WriteHeader(400)
+			return
+		}
+
+		u.mu.Lock()
+		defer u.mu.Unlock()
+		u.posts++
+		if u.status != 0 {
+			if u.resetHdr != "" {
+				w.Header().Set("X-Rate-Limit-Reset", u.resetHdr)
+			}
+			w.WriteHeader(u.status)
+			fmt.Fprint(w, `{"error":"nope"}`)
+			return
+		}
+		u.got = append(u.got, req.Hits...)
+		w.WriteHeader(http.StatusAccepted)
 	}))
 	t.Cleanup(u.Close)
 	return u

--- a/cmd/goatcounter/proxy_test.go
+++ b/cmd/goatcounter/proxy_test.go
@@ -1,0 +1,633 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"zgo.at/goatcounter/v2/handlers"
+	"zgo.at/json"
+	"zgo.at/zli"
+)
+
+// upstream is a minimal GoatCounter server that only implements the two
+// endpoints the proxy talks to: /api/v0/me (for checkSite) and /api/v0/count.
+// The reply to /api/v0/count can be changed while the test runs, to act like a
+// server that is down for a while.
+type upstream struct {
+	*httptest.Server
+
+	mu       sync.Mutex
+	got      []handlers.APICountRequestHit
+	posts    int
+	status   int    // Reply with this instead of accepting
+	resetHdr string // X-Rate-Limit-Reset to send along with the status
+}
+
+func newUpstream(t *testing.T) *upstream {
+	t.Helper()
+
+	u := new(upstream)
+	u.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v0/me":
+			// permissions=2 is APIPermCount.
+			fmt.Fprint(w, `{"token":{"name":"test","permissions":2}}`)
+		case "/api/v0/count":
+			var req handlers.APICountRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode count request: %s", err)
+				w.WriteHeader(400)
+				return
+			}
+
+			u.mu.Lock()
+			defer u.mu.Unlock()
+			u.posts++
+			if u.status != 0 {
+				if u.resetHdr != "" {
+					w.Header().Set("X-Rate-Limit-Reset", u.resetHdr)
+				}
+				w.WriteHeader(u.status)
+				fmt.Fprint(w, `{"error":"nope"}`)
+				return
+			}
+			u.got = append(u.got, req.Hits...)
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			t.Errorf("unexpected request to %s", r.URL.Path)
+			w.WriteHeader(404)
+		}
+	}))
+	t.Cleanup(u.Close)
+	return u
+}
+
+// reply makes /api/v0/count answer with this status. 0 accepts pageviews again.
+func (u *upstream) reply(status int, reset string) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.status, u.resetHdr = status, reset
+}
+
+func (u *upstream) hits() []handlers.APICountRequestHit {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return append([]handlers.APICountRequestHit(nil), u.got...)
+}
+
+func (u *upstream) numPosts() int {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return u.posts
+}
+
+// waitFor polls until f returns true, or fails the test after a few seconds.
+func waitFor(t *testing.T, what string, f func() bool) {
+	t.Helper()
+	for range 200 {
+		if f() {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for %s", what)
+}
+
+// startProxy runs the proxy command against an upstream and returns a function
+// to shut it down.
+func startProxy(t *testing.T, listen string, args ...string) func() {
+	t.Helper()
+
+	exit, _, _ := zli.Test(t)
+	ready := make(chan struct{}, 1)
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		runCmdStop(t, exit, ready, stop, "proxy", append([]string{"-listen=" + listen}, args...)...)
+		close(done)
+	}()
+	<-ready
+
+	var once sync.Once
+	shutdown := func() {
+		once.Do(func() {
+			close(stop)
+			<-done
+		})
+	}
+	t.Cleanup(shutdown)
+	return shutdown
+}
+
+func sendCount(t *testing.T, listen, query string) *http.Response {
+	t.Helper()
+	r, err := http.NewRequest("GET", "http://"+listen+"/count?"+query, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64) Firefox/130.0")
+	resp, err := http.DefaultClient.Do(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func TestProxy(t *testing.T) {
+	up := newUpstream(t)
+	t.Setenv("GOATCOUNTER_API_KEY", "test-key")
+
+	const listen = "localhost:9923"
+	shutdown := startProxy(t, listen,
+		"-site="+up.URL,
+		"-ratelimit=off",
+		"-batch-min-time=50ms",
+		"-batch-max-time=500ms")
+
+	for i := range 3 {
+		resp := sendCount(t, listen, "p=/page"+strconv.Itoa(i)+"&t=Title"+strconv.Itoa(i))
+		if resp.StatusCode != 200 {
+			t.Fatalf("/count returned %d", resp.StatusCode)
+		}
+		if ct := resp.Header.Get("Content-Type"); ct != "image/gif" {
+			t.Errorf("Content-Type = %q, want image/gif", ct)
+		}
+		resp.Body.Close()
+	}
+
+	waitFor(t, "3 forwarded pageviews", func() bool { return len(up.hits()) >= 3 })
+	shutdown()
+
+	got := up.hits()
+	if len(got) != 3 {
+		t.Fatalf("forwarded %d pageviews, want 3", len(got))
+	}
+	for i, h := range got {
+		if want := "/page" + strconv.Itoa(i); h.Path != want {
+			t.Errorf("pageview %d: Path = %q, want %q", i, h.Path, want)
+		}
+		if want := "Title" + strconv.Itoa(i); h.Title != want {
+			t.Errorf("pageview %d: Title = %q, want %q", i, h.Title, want)
+		}
+		if h.UserAgent == "" {
+			t.Errorf("pageview %d: UserAgent is empty", i)
+		}
+		if h.IP == "" {
+			t.Errorf("pageview %d: IP is empty", i)
+		}
+		if h.CreatedAt.IsZero() {
+			t.Errorf("pageview %d: CreatedAt is zero", i)
+		}
+	}
+}
+
+func TestProxyRatelimit(t *testing.T) {
+	up := newUpstream(t)
+	t.Setenv("GOATCOUNTER_API_KEY", "test-key")
+
+	const listen = "localhost:9924"
+	shutdown := startProxy(t, listen,
+		"-site="+up.URL,
+		"-ratelimit=2/1",
+		"-batch-min-time=50ms",
+		"-batch-max-time=500ms")
+
+	var ok, limited int
+	for range 10 {
+		resp := sendCount(t, listen, "p=/x")
+		switch resp.StatusCode {
+		case 200:
+			ok++
+		case http.StatusTooManyRequests:
+			limited++
+		default:
+			t.Errorf("unexpected status %d", resp.StatusCode)
+		}
+		resp.Body.Close()
+	}
+
+	if limited == 0 {
+		t.Errorf("expected some requests to be rate limited, got %d ok / %d limited", ok, limited)
+	}
+	// Only the non-limited requests should have been forwarded.
+	waitFor(t, "the non-limited pageviews", func() bool { return len(up.hits()) >= ok })
+	shutdown()
+
+	if n := len(up.hits()); n != ok {
+		t.Errorf("forwarded %d pageviews, want %d (the non-limited ones)", n, ok)
+	}
+}
+
+// A batch is kept and retried while the upstream server is unavailable, and
+// forwarded once it comes back.
+func TestProxyUpstreamOutage(t *testing.T) {
+	up := newUpstream(t)
+	t.Setenv("GOATCOUNTER_API_KEY", "test-key")
+
+	// What a proxy in front of a dead GoatCounter server would say.
+	up.reply(http.StatusServiceUnavailable, "")
+
+	const listen = "localhost:9925"
+	shutdown := startProxy(t, listen,
+		"-site="+up.URL,
+		"-ratelimit=off",
+		"-batch-min-time=50ms",
+		"-batch-max-time=200ms")
+
+	resp := sendCount(t, listen, "p=/down")
+	resp.Body.Close()
+
+	// The batch is tried, fails, and is kept for later.
+	waitFor(t, "the first attempt", func() bool { return up.numPosts() >= 1 })
+	if n := len(up.hits()); n != 0 {
+		t.Fatalf("forwarded %d pageviews while the server was down, want 0", n)
+	}
+
+	up.reply(0, "") // Server is back.
+	waitFor(t, "the pageview after recovery", func() bool { return len(up.hits()) == 1 })
+
+	shutdown()
+	if got := up.hits(); got[0].Path != "/down" {
+		t.Errorf("Path = %q, want /down", got[0].Path)
+	}
+}
+
+// While the forwarding goroutine is stuck retrying, /count keeps answering and
+// the queue keeps the most recent pageviews rather than the first ones.
+func TestProxyKeepsServingDuringOutage(t *testing.T) {
+	up := newUpstream(t)
+	t.Setenv("GOATCOUNTER_API_KEY", "test-key")
+
+	up.reply(http.StatusBadGateway, "")
+
+	const (
+		listen = "localhost:9928"
+		queue  = 5
+		total  = 40
+	)
+	shutdown := startProxy(t, listen,
+		"-site="+up.URL,
+		"-ratelimit=off",
+		"-queue="+strconv.Itoa(queue),
+		"-batch=2",
+		"-batch-min-time=10ms",
+		"-batch-max-time=50ms")
+
+	// The upstream server is unreachable for all of this, so none of these may
+	// wait on it.
+	start := time.Now()
+	for i := range total {
+		resp := sendCount(t, listen, "p=/p"+strconv.Itoa(i))
+		if resp.StatusCode != 200 {
+			t.Fatalf("/count returned %d while the upstream server was down", resp.StatusCode)
+		}
+		resp.Body.Close()
+	}
+	if d := time.Since(start); d > 2*time.Second {
+		t.Errorf("%d requests took %s: /count waited for the upstream server", total, d)
+	}
+	waitFor(t, "the first attempt", func() bool { return up.numPosts() >= 1 })
+
+	up.reply(0, "") // Server is back.
+	// Wait until nothing new arrives for a while: the backlog is through.
+	var n int
+	for {
+		time.Sleep(250 * time.Millisecond)
+		if got := len(up.hits()); got == n {
+			break
+		} else {
+			n = got
+		}
+	}
+	shutdown()
+
+	got := up.hits()
+	if len(got) == 0 {
+		t.Fatal("nothing was forwarded after the upstream server came back")
+	}
+	if len(got) >= total {
+		t.Errorf("forwarded %d of %d pageviews; a queue of %d should have dropped some",
+			len(got), total, queue)
+	}
+
+	// Whatever came through must be pageviews we sent, in order, and has to
+	// include the last one: the oldest are dropped, never the newest.
+	seen := make(map[string]bool, len(got))
+	last := -1
+	for _, h := range got {
+		i, err := strconv.Atoi(strings.TrimPrefix(h.Path, "/p"))
+		if err != nil || i >= total {
+			t.Fatalf("forwarded a pageview we never sent: %q", h.Path)
+		}
+		if seen[h.Path] {
+			t.Errorf("forwarded %q twice", h.Path)
+		}
+		seen[h.Path] = true
+		if i < last {
+			t.Errorf("pageview %q came after /p%d: batches are out of order", h.Path, last)
+		}
+		last = i
+	}
+	if want := "/p" + strconv.Itoa(total-1); !seen[want] {
+		t.Errorf("%s was not forwarded; the newest pageviews should be the ones kept", want)
+	}
+}
+
+// A 4xx means the batch itself is wrong, so it's dropped instead of retried.
+func TestProxyFatalStatus(t *testing.T) {
+	up := newUpstream(t)
+	t.Setenv("GOATCOUNTER_API_KEY", "test-key")
+
+	up.reply(http.StatusUnauthorized, "") // e.g. the API key was revoked.
+
+	const listen = "localhost:9926"
+	shutdown := startProxy(t, listen,
+		"-site="+up.URL,
+		"-ratelimit=off",
+		"-batch-min-time=50ms",
+		"-batch-max-time=200ms")
+
+	resp := sendCount(t, listen, "p=/gone")
+	resp.Body.Close()
+
+	waitFor(t, "the only attempt", func() bool { return up.numPosts() >= 1 })
+
+	// Well past the first retry wait of one second: it must not come back.
+	time.Sleep(1500 * time.Millisecond)
+	if n := up.numPosts(); n != 1 {
+		t.Errorf("posted %d times, want 1: a 401 should not be retried", n)
+	}
+	shutdown()
+}
+
+// A 429 is retried after the delay the server asks for.
+func TestProxyUpstreamRatelimited(t *testing.T) {
+	up := newUpstream(t)
+	t.Setenv("GOATCOUNTER_API_KEY", "test-key")
+
+	up.reply(http.StatusTooManyRequests, "1")
+
+	const listen = "localhost:9927"
+	shutdown := startProxy(t, listen,
+		"-site="+up.URL,
+		"-ratelimit=off",
+		"-batch-min-time=50ms",
+		"-batch-max-time=200ms")
+
+	resp := sendCount(t, listen, "p=/slow")
+	resp.Body.Close()
+
+	waitFor(t, "the rate limited attempt", func() bool { return up.numPosts() >= 1 })
+	up.reply(0, "")
+	waitFor(t, "the pageview after the rate limit", func() bool { return len(up.hits()) == 1 })
+	shutdown()
+}
+
+func TestHitQueue(t *testing.T) {
+	ctx := context.Background()
+	push := func(q *hitQueue, paths ...string) {
+		for _, p := range paths {
+			q.push(ctx, handlers.APICountRequestHit{Path: p, CreatedAt: time.Now().UTC()})
+		}
+	}
+	paths := func(hits []handlers.APICountRequestHit) []string {
+		p := make([]string, len(hits))
+		for i, h := range hits {
+			p[i] = h.Path
+		}
+		return p
+	}
+	wantPop := func(t *testing.T, q *hitQueue, max int, want ...string) {
+		t.Helper()
+		got := paths(q.pop(max))
+		if fmt.Sprint(got) != fmt.Sprint(want) {
+			t.Errorf("pop(%d) = %v, want %v", max, got, want)
+		}
+	}
+
+	t.Run("fifo", func(t *testing.T) {
+		q := newHitQueue(5)
+		push(q, "/a", "/b", "/c")
+		if q.n != 3 {
+			t.Errorf("size = %d, want 3", q.n)
+		}
+		wantPop(t, q, 2, "/a", "/b")
+		wantPop(t, q, 2, "/c")
+		if q.n != 0 {
+			t.Errorf("size = %d, want 0", q.n)
+		}
+		if got := q.pop(1); got != nil {
+			t.Errorf("pop on empty queue = %v, want nil", got)
+		}
+	})
+
+	t.Run("drops oldest when full", func(t *testing.T) {
+		q := newHitQueue(3)
+		push(q, "/a", "/b", "/c", "/d", "/e")
+		if q.n != 3 {
+			t.Errorf("size = %d, want 3", q.n)
+		}
+		if d := q.dropped; d != 2 {
+			t.Errorf("numDropped = %d, want 2", d)
+		}
+		wantPop(t, q, 10, "/c", "/d", "/e")
+	})
+
+	t.Run("grows up to max", func(t *testing.T) {
+		q := newHitQueue(5)
+		if len(q.buf) != 5 {
+			t.Errorf("small queue was allocated as %d, want 5", len(q.buf))
+		}
+
+		q = newHitQueue(3 * hitQueueMin)
+		if len(q.buf) != hitQueueMin {
+			t.Errorf("initial ring is %d, want %d", len(q.buf), hitQueueMin)
+		}
+		for i := range 3 * hitQueueMin {
+			push(q, "/"+strconv.Itoa(i))
+		}
+		if len(q.buf) != 3*hitQueueMin {
+			t.Errorf("ring grew to %d, want %d", len(q.buf), 3*hitQueueMin)
+		}
+		if q.n != 3*hitQueueMin {
+			t.Errorf("size = %d, want %d", q.n, 3*hitQueueMin)
+		}
+		if d := q.dropped; d != 0 {
+			t.Errorf("numDropped = %d, want 0: the queue should have grown instead", d)
+		}
+		// Everything is still there, in order, after two rounds of growing.
+		got := q.pop(3 * hitQueueMin)
+		for i, h := range got {
+			if want := "/" + strconv.Itoa(i); h.Path != want {
+				t.Fatalf("pageview %d: Path = %q, want %q", i, h.Path, want)
+			}
+		}
+	})
+
+	t.Run("shrinks back down as the backlog clears", func(t *testing.T) {
+		q := newHitQueue(8 * hitQueueMin)
+		for i := range 8 * hitQueueMin {
+			push(q, "/"+strconv.Itoa(i))
+		}
+		if len(q.buf) != 8*hitQueueMin {
+			t.Fatalf("ring grew to %d, want %d", len(q.buf), 8*hitQueueMin)
+		}
+
+		// Just over a quarter in use is not enough to halve it: that would
+		// leave the ring completely full.
+		q.pop(6*hitQueueMin - 1)
+		if want := 8 * hitQueueMin; len(q.buf) != want {
+			t.Errorf("ring is %d with %d of %d in use, want %d", len(q.buf), q.n, want, want)
+		}
+
+		// At the quarter mark it halves once, and the result is half empty.
+		q.pop(1)
+		if want := 4 * hitQueueMin; len(q.buf) != want {
+			t.Errorf("ring is %d, want %d", len(q.buf), want)
+		}
+
+		// Emptying it goes all the way back down, but no further.
+		q.pop(8 * hitQueueMin)
+		if q.n != 0 {
+			t.Fatalf("size = %d, want 0", q.n)
+		}
+		if len(q.buf) != hitQueueMin {
+			t.Errorf("empty ring is %d, want %d", len(q.buf), hitQueueMin)
+		}
+
+		// The pageviews left over survive the shrinking, in order.
+		q = newHitQueue(4 * hitQueueMin)
+		for i := range 4 * hitQueueMin {
+			push(q, "/"+strconv.Itoa(i))
+		}
+		q.pop(4*hitQueueMin - 3)
+		if len(q.buf) != hitQueueMin {
+			t.Errorf("ring is %d, want %d", len(q.buf), hitQueueMin)
+		}
+		wantPop(t, q, 10,
+			"/"+strconv.Itoa(4*hitQueueMin-3),
+			"/"+strconv.Itoa(4*hitQueueMin-2),
+			"/"+strconv.Itoa(4*hitQueueMin-1))
+	})
+
+	t.Run("never shrinks below its own max", func(t *testing.T) {
+		// A queue smaller than hitQueueMin starts at its max and stays there.
+		q := newHitQueue(4)
+		push(q, "/a", "/b", "/c", "/d")
+		q.pop(4)
+		if len(q.buf) != 4 {
+			t.Errorf("ring is %d, want 4", len(q.buf))
+		}
+	})
+
+	t.Run("grows from a wrapped ring", func(t *testing.T) {
+		q := newHitQueue(8)
+		q.buf = make([]handlers.APICountRequestHit, 2) // Pretend it hasn't grown yet.
+		push(q, "/a", "/b")
+		wantPop(t, q, 1, "/a")
+		push(q, "/c", "/d") // Wraps, then grows while wrapped.
+		wantPop(t, q, 10, "/b", "/c", "/d")
+	})
+
+	t.Run("wraps around", func(t *testing.T) {
+		q := newHitQueue(3)
+		push(q, "/a", "/b")
+		wantPop(t, q, 2, "/a", "/b")
+		push(q, "/c", "/d", "/e") // Writes across the end of the ring.
+		wantPop(t, q, 10, "/c", "/d", "/e")
+		if d := q.dropped; d != 0 {
+			t.Errorf("numDropped = %d, want 0", d)
+		}
+	})
+
+	t.Run("oldest", func(t *testing.T) {
+		q := newHitQueue(3)
+		if _, ok := q.oldest(); ok {
+			t.Error("oldest on an empty queue returned ok")
+		}
+		first := time.Now().UTC()
+		q.push(ctx, handlers.APICountRequestHit{Path: "/a", CreatedAt: first})
+		q.push(ctx, handlers.APICountRequestHit{Path: "/b", CreatedAt: first.Add(time.Second)})
+		got, ok := q.oldest()
+		if !ok || !got.Equal(first) {
+			t.Errorf("oldest = %s, %t; want %s, true", got, ok, first)
+		}
+	})
+
+	t.Run("pop frees the strings", func(t *testing.T) {
+		q := newHitQueue(2)
+		push(q, "/a", "/b")
+		q.pop(2)
+		for i, h := range q.buf {
+			if h.Path != "" {
+				t.Errorf("slot %d still holds %q after pop", i, h.Path)
+			}
+		}
+	})
+}
+
+func TestRetryableStatus(t *testing.T) {
+	tests := []struct {
+		code int
+		want bool
+	}{
+		{http.StatusBadRequest, false},
+		{http.StatusUnauthorized, false},
+		{http.StatusForbidden, false},
+		{http.StatusNotFound, false},
+		{http.StatusRequestEntityTooLarge, false},
+		{http.StatusUnsupportedMediaType, false},
+		{http.StatusRequestTimeout, true},
+		{http.StatusTooEarly, true},
+		{http.StatusInternalServerError, true},
+		{http.StatusBadGateway, true},
+		{http.StatusServiceUnavailable, true},
+		{http.StatusGatewayTimeout, true},
+	}
+	for _, tt := range tests {
+		if got := retryableStatus(tt.code); got != tt.want {
+			t.Errorf("retryableStatus(%d) = %t, want %t", tt.code, got, tt.want)
+		}
+	}
+}
+
+func TestRetryWait(t *testing.T) {
+	want := []time.Duration{time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second}
+	for i, w := range want {
+		if got := retryWait(i); got != w {
+			t.Errorf("retryWait(%d) = %s, want %s", i, got, w)
+		}
+	}
+	for _, n := range []int{6, 10, 100, 1000} {
+		if got := retryWait(n); got != maxRetryWait {
+			t.Errorf("retryWait(%d) = %s, want %s", n, got, maxRetryWait)
+		}
+	}
+}
+
+func TestRetryAfter(t *testing.T) {
+	tests := []struct {
+		hdr  http.Header
+		want time.Duration
+	}{
+		{http.Header{}, 0},
+		{http.Header{"X-Rate-Limit-Reset": {"5"}}, 5 * time.Second},
+		{http.Header{"Retry-After": {"7"}}, 7 * time.Second},
+		{http.Header{"X-Rate-Limit-Reset": {"0"}, "Retry-After": {"7"}}, 7 * time.Second},
+		{http.Header{"X-Rate-Limit-Reset": {"-3"}}, 0},
+		{http.Header{"X-Rate-Limit-Reset": {"nope"}}, 0},
+		{http.Header{"X-Rate-Limit-Reset": {"99999"}}, maxRateLimitWait},
+	}
+	for _, tt := range tests {
+		if got := retryAfter(tt.hdr); got != tt.want {
+			t.Errorf("retryAfter(%v) = %s, want %s", tt.hdr, got, tt.want)
+		}
+	}
+}

--- a/handlers/count.go
+++ b/handlers/count.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"fmt"
-	"math"
 	"net/http"
 
 	"github.com/monoculum/formam/v3"
@@ -90,12 +89,6 @@ func (h backend) count(w http.ResponseWriter, r *http.Request) error {
 		w.Header().Add("X-Goatcounter", fmt.Sprintf("ignored because path is longer than 2048 bytes (%d bytes)", len(r.RequestURI)))
 		w.WriteHeader(400)
 		return zhttp.Bytes(w, gif)
-	}
-	for _, s := range hit.Size {
-		if s > math.MaxInt32 {
-			w.Header().Add("X-Goatcounter", fmt.Sprintf("ignored because screen size %v is out of range of int32", s))
-			w.WriteHeader(400)
-		}
 	}
 
 	if isbot.Is(bot) { // Prefer the backend detection.

--- a/hit.go
+++ b/hit.go
@@ -2,6 +2,8 @@ package goatcounter
 
 import (
 	"context"
+	"fmt"
+	"math"
 	"net/url"
 	"strings"
 	"time"
@@ -317,6 +319,11 @@ func (h *Hit) Validate(ctx context.Context, initial bool) error {
 		v.Len("path", h.Path, 1, 2048)
 		v.Len("title", h.Title, 0, 1024)
 		v.Len("user_agent_header", h.UserAgentHeader, 0, 512)
+		for _, s := range h.Size {
+			if s > math.MaxInt32 {
+				v.Append("size", fmt.Sprintf("screen size %v is out of range of int32", s))
+			}
+		}
 	} else if h.Bot == 0 {
 		v.Required("path_id", h.PathID)
 


### PR DESCRIPTION
The proxy can be distributed at the edge and keep page counts if there
is a reachability issue with the remote Goatcounter server.

The tests are a bit slow, but once we switch to Go 1.27, we can speed
them up by using synctest with the new httptest in-memory server.

There are two subsequent commits:
1. Do not validate the token to ensure the daemon does not crash on start if the remote is not reachable yet.
2. Check `hit.Size` inside `Validate()`

You may want to wait 1 month for me to report if it works correctly! Initially, I didn't want to publish it, but maybe you'll find it useful.