### PR TITLE
Keep the saved view's grouping on dashboard load

### DIFF
--- a/handlers/dashboard.go
+++ b/handlers/dashboard.go
@@ -431,6 +431,7 @@ func getPeriod(w http.ResponseWriter, r *http.Request, site *goatcounter.Site, u
 func getGroup(r *http.Request, g goatcounter.Group, rng ztime.Range) (goatcounter.Group, goatcounter.Groups) {
 	var (
 		allow goatcounter.Groups
+		saved = g
 		d     = rng.End.Sub(rng.Start).Hours() / 24
 	)
 	// Viewing by hour for a year or viewing by day for 2 days looks horrible,
@@ -448,6 +449,12 @@ func getGroup(r *http.Request, g goatcounter.Group, rng ztime.Range) (goatcounte
 		g, allow = goatcounter.GroupHourly, append(allow, goatcounter.GroupHourly, goatcounter.GroupDaily)
 	case d > 90:
 		g, allow = goatcounter.GroupDaily, append(allow, goatcounter.GroupDaily, goatcounter.GroupWeekly)
+	}
+
+	// Keep the grouping from the saved view if it makes sense for this period,
+	// instead of always resetting it to the default.
+	if slices.Contains(allow, saved) {
+		g = saved
 	}
 
 	switch gg := strings.ToLower(r.URL.Query().Get("group")); {

--- a/handlers/dashboard_test.go
+++ b/handlers/dashboard_test.go
@@ -2,9 +2,12 @@ package handlers
 
 import (
 	"context"
+	"net/http/httptest"
+	"slices"
 	"testing"
 	"time"
 
+	"zgo.at/goatcounter/v2"
 	"zgo.at/zstd/ztime"
 )
 
@@ -21,6 +24,51 @@ func TestDashboard(t *testing.T) {
 
 	for _, tt := range tests {
 		runTest(t, tt, nil)
+	}
+}
+
+func TestGetGroup(t *testing.T) {
+	tests := []struct {
+		days      int
+		saved     goatcounter.Group
+		query     string
+		wantGroup goatcounter.Group
+		wantAllow goatcounter.Groups
+	}{
+		{3, goatcounter.GroupHourly, "", goatcounter.GroupHourly,
+			goatcounter.Groups{goatcounter.GroupHourly}},
+		{3, goatcounter.GroupDaily, "", goatcounter.GroupHourly,
+			goatcounter.Groups{goatcounter.GroupHourly}},
+
+		{30, goatcounter.GroupHourly, "", goatcounter.GroupHourly,
+			goatcounter.Groups{goatcounter.GroupHourly, goatcounter.GroupDaily}},
+		{30, goatcounter.GroupDaily, "", goatcounter.GroupDaily,
+			goatcounter.Groups{goatcounter.GroupHourly, goatcounter.GroupDaily}},
+		{30, goatcounter.GroupWeekly, "", goatcounter.GroupHourly,
+			goatcounter.Groups{goatcounter.GroupHourly, goatcounter.GroupDaily}},
+		{30, goatcounter.GroupDaily, "hour", goatcounter.GroupHourly,
+			goatcounter.Groups{goatcounter.GroupHourly, goatcounter.GroupDaily}},
+
+		{120, goatcounter.GroupHourly, "", goatcounter.GroupDaily,
+			goatcounter.Groups{goatcounter.GroupDaily, goatcounter.GroupWeekly}},
+		{120, goatcounter.GroupWeekly, "", goatcounter.GroupWeekly,
+			goatcounter.Groups{goatcounter.GroupDaily, goatcounter.GroupWeekly}},
+
+		{365, goatcounter.GroupMonthly, "", goatcounter.GroupMonthly,
+			goatcounter.Groups{goatcounter.GroupDaily, goatcounter.GroupWeekly, goatcounter.GroupMonthly}},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			start := ztime.FromString("2020-06-18")
+			rng := ztime.NewRange(start).To(start.AddDate(0, 0, tt.days).Add(24*time.Hour - time.Second))
+
+			r := httptest.NewRequest("GET", "/?group="+tt.query, nil)
+			group, allow := getGroup(r, tt.saved, rng)
+			if group != tt.wantGroup || !slices.Equal(allow, tt.wantAllow) {
+				t.Errorf("\nhave: %s, %s\nwant: %s, %s", group, allow, tt.wantGroup, tt.wantAllow)
+			}
+		})
 	}
 }
 
@@ -56,7 +104,7 @@ func TestTimeRange(t *testing.T) {
 				gotEnd := rng.End.Format("2006-01-02 15:04:05")
 
 				if gotStart != tt.wantStart || gotEnd != tt.wantEnd {
-					t.Errorf("\ngot:  %q, %q\nwant: %q, %q",
+					t.Errorf("\nhave: %q, %q\nwant: %q, %q",
 						gotStart, gotEnd, tt.wantStart, tt.wantEnd)
 				}
 			})


### PR DESCRIPTION
Saving a default view with "view by: day" for a period under 90 days (e.g. "last week, view by day") never worked: the next dashboard load always came back as "view by: hour".

The cause is in getGroup(): it receives the group from the saved view, but the first switch unconditionally overwrites it with the period's default, and only the group= query parameter can restore it. A fresh dashboard load has no group= parameter, so the saved value is always discarded.

This keeps the saved grouping when it's in the allowed set for the period. An explicit group= in the URL still wins, and the period-length defaults are untouched, so:

- users who never saved a grouping see no change (the zero value is GroupHourly, which was already the default for periods under 90 days, and it's not in the allowed set for longer periods so those still fall back to daily);
- a saved grouping that makes no sense for the period (e.g. weekly for a 30-day range) still falls back to the default.

Added a small table test for getGroup covering the buckets, the saved-group cases, and the query-parameter override.