### PR TITLE
Tell the user when the start date is limited to the first pageview

### DIFF
--- a/handlers/dashboard.go
+++ b/handlers/dashboard.go
@@ -418,7 +418,15 @@ func getPeriod(w http.ResponseWriter, r *http.Request, site *goatcounter.Site, u
 	c := site.FirstHitAt.Add(-24 * time.Hour * 7)
 	if rng.Start.Before(c) {
 		y, m, d := c.In(user.Settings.Timezone.Loc()).Date()
-		rng.Start = time.Date(y, m, d, 0, 0, 0, 0, user.Settings.Timezone.Loc())
+		clamped := time.Date(y, m, d, 0, 0, 0, 0, user.Settings.Timezone.Loc())
+		// Only tell the user if they actually asked for an earlier date; this
+		// is also reached when there's no period-start in the query at all.
+		if !rng.Start.IsZero() {
+			zhttp.Flash(w, r, T(r.Context(),
+				"notify/period-start-clamped|The site has no data that far back; the start date was set to %(date).",
+				clamped.Format("2006-01-02")))
+		}
+		rng.Start = clamped
 	}
 	if rng.End.Before(c) && !rng.End.IsZero() {
 		y, m, d := c.In(user.Settings.Timezone.Loc()).Date()


### PR DESCRIPTION
When the requested date range starts more than a week before the site's first pageview, getPeriod() silently moves the start date up. On a site that's only a few weeks old this is quite confusing: clicking "last quarter" shows a much shorter range than asked for, with nothing explaining why. It also changes which "view by" options are offered (those depend on the range length), so the dashboard appears to change its options at random.

This flashes a short message when the adjustment happens, using the existing flash mechanism. It only fires when an explicit start date was submitted, since the same branch is also reached when there's no period-start in the query at all.

To be clear: this one is more a suggestion about the UX gap than a definite fix; maybe you'd rather surface it differently (e.g. in the timerange display) or word it differently, so feel free to discard or rework it.