### PR TITLE
Round the number of days when saving a dashboard view

### DIFF
--- a/handlers/dashboard.go
+++ b/handlers/dashboard.go
@@ -383,9 +383,11 @@ func timeRange(ctx context.Context, r string, tz *time.Location, sundayStartsWee
 	case "year":
 		rng = rng.Last(ztime.Year)
 	default:
-		// Sometimes the frontend sends something like "54.958333333333336"
-		// presumably due to to JS numbers always being a float. Not entirely
-		// sure where this happens, so just deal with it here.
+		// This can be a fraction such as "54.958333333333336" for views that
+		// were saved from dashboard.js before it rounded the number: it
+		// divided the difference of two dates at local midnight by 24 hours,
+		// and with a DST transition in the range that's not a whole number.
+		// Keep rounding here for views that were saved like that.
 		days, err := strconv.ParseFloat(r, 32)
 		if err != nil {
 			log.Error(ctx, errors.Errorf("timeRange: %w", err), "rng", r)

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -412,7 +412,9 @@
 			e.preventDefault()
 			var p = $('#dash-select-period').attr('class').substr(7)
 			if (p === '')
-				p = (get_date($('#period-end').val()) - get_date($('#period-start').val())) / 86400000
+				// Round because the dates are at local midnight, and with a DST
+				// transition in the range a "day" isn't always 24 hours.
+				p = Math.round((get_date($('#period-end').val()) - get_date($('#period-start').val())) / 86400000)
 
 			var done = paginate_button($(this), () => {
 				jQuery.ajax({


### PR DESCRIPTION
This answers the "Not entirely sure where this happens" comment in timeRange() about fractional periods like "54.958333333333336".

They come from the save-current-view handler in dashboard.js: when no period button is active (for example after moving the range with the back/forward buttons, which clear the period class), it computes the period as (end - start) / 86400000 from two Date objects at local midnight. With a DST transition inside the range one of those "days" is 23 or 25 hours, so the result is a fraction (54.958333... is exactly 55 days minus one hour).

Changes:

- dashboard.js rounds the number before saving the view;
- the comment in timeRange() now explains the actual cause;
- the server-side rounding itself is kept, since already-saved views can still contain fractions.