### PR TITLE
Apply the first-pageview date limit to saved views too

### DIFF
--- a/handlers/dashboard.go
+++ b/handlers/dashboard.go
@@ -65,6 +65,15 @@ func (h backend) dashboard(w http.ResponseWriter, r *http.Request) error {
 		if err != nil {
 			return err
 		}
+
+		// Apply the same "a week before the first pageview at the most" limit
+		// that getPeriod() applies to explicit dates, so the first render of a
+		// saved view doesn't show a longer range (with different "view by"
+		// options) than submitting the dashboard form it renders.
+		if c := site.FirstHitAt.Add(-24 * time.Hour * 7); rng.Start.Before(c) {
+			y, m, d := c.In(user.Settings.Timezone.Loc()).Date()
+			rng.Start = time.Date(y, m, d, 0, 0, 0, 0, user.Settings.Timezone.Loc()).UTC()
+		}
 	} else {
 		view.Period = strings.TrimSuffix(q.Get("hl-period"), "-cur")
 	}
@@ -446,7 +455,7 @@ func getGroup(r *http.Request, g goatcounter.Group, rng ztime.Range) (goatcounte
 		g, allow = goatcounter.GroupDaily, append(allow, goatcounter.GroupDaily, goatcounter.GroupWeekly, goatcounter.GroupMonthly)
 	case d < 90:
 		g, allow = goatcounter.GroupHourly, append(allow, goatcounter.GroupHourly, goatcounter.GroupDaily)
-	case d > 90:
+	case d >= 90:
 		g, allow = goatcounter.GroupDaily, append(allow, goatcounter.GroupDaily, goatcounter.GroupWeekly)
 	}
 


### PR DESCRIPTION
getPeriod() adjusts explicit date ranges to start no more than a week before the site's first pageview, but the fallback path that renders a saved view from its period name (timeRange) doesn't. On a site younger than the saved period, the first render shows a different range than any later submit of the exact same dashboard form, and since the "view by" options depend on the range length, the dashboard appears to change its options at random.

Concrete repro (seen on my five-week-old site with a saved "quarter" default view):

1. Load the dashboard: the range is the full ~92 days, so it offers "view by: day, week" with day selected.
2. Click the "day" button (or type in the filter, or click any period button): the form submits the visible dates, getPeriod() limits them to ~45 days, and the options flip to "hour, day".
3. Click "week" instead: same flip, but since weekly isn't allowed for a 45-day range it silently falls back to viewing by hour.

This applies the same limit after the timeRange() fallback, so the first render and every later submit agree on the range. I kept the few lines inline rather than extracting a helper to keep the diff small; happy to restructure if you'd rather share the code with getPeriod().

Also closes a small gap in getGroup(): a range of exactly 90.0 days matched neither d < 90 nor d > 90, so no groupings were allowed at all and the "view by" row would render without any buttons. Not reachable through the UI (the end date is always at 23:59:59, so the length is never a whole number), but it's free to fix.

Related: #911 suggests telling the user when the limit kicks in; the two are independent and don't conflict.