### PR TITLE
Don't apply the timezone offset to the back/forward buttons

### DIFF
--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -165,12 +165,6 @@
 
 	// Set the start and end period and submit the form.
 	var set_period = function(start, end) {
-		if (TZ_OFFSET) {
-			var offset = (start.getTimezoneOffset() + TZ_OFFSET) / 60
-			start.setHours(start.getHours() + offset)
-			end.setHours(end.getHours() + offset)
-		}
-
 		$('#period-start').val(format_date_ymd(start))
 		$('#period-end').val(format_date_ymd(end))
 		$('#dash-form').trigger('submit')
@@ -226,6 +220,16 @@
 			e.preventDefault()
 
 			var start = new Date(), end = new Date()
+			// Adjust the browser's "now" to the timezone from the user
+			// settings, which is what the dashboard displays; near midnight
+			// the two can be on different dates. The back/forward buttons
+			// below need no adjustment, as they operate on the displayed
+			// dates, which are already in that timezone.
+			if (TZ_OFFSET) {
+				var offset = (start.getTimezoneOffset() + TZ_OFFSET) / 60
+				start.setHours(start.getHours() + offset)
+				end.setHours(end.getHours() + offset)
+			}
 			switch (this.value) {
 				case 'day':       /* Do nothing */ break
 				case 'week':      start.setDate(start.getDate() - 7);   break;


### PR DESCRIPTION
Fixes #895.

The timezone adjustment in set_period() converts the browser's clock to the timezone from the user settings. That's needed for its first caller, the "Last day / week / month ..." buttons, which start from new Date() in the browser's timezone. But set_period() is also called by the back/forward move buttons, and those pass calendar dates parsed from the period fields, which are already in the settings timezone. Since parsed dates sit at midnight, any westward difference between the two timezones pushes them across midnight into the previous day when they're formatted back to a date.

That reproduces the report exactly. Browser in Europe/London (BST, getTimezoneOffset() = -60), account timezone America/Detroit (data-offset = -240), so the adjustment is (-60 + -240) / 60 = -5 hours:

- "back day" from Aug 9: computes Aug 8 00:00, the adjustment makes it Aug 7 19:00, formatted as Aug 7. Two days back.
- "forward day": computes Aug 10 00:00, becomes Aug 9 19:00, formatted as Aug 9. No movement.

It also matches your observation in the issue that it only reproduces with a mismatched account timezone: when browser and account agree the offset is zero and the extra adjustment is a no-op.

The fix moves the adjustment out of set_period() into the period-buttons handler, the only caller that starts from the browser's "now". The week/month/year move buttons had the same off-by-one and are covered by the same change.

One thing deliberately left out of scope: the "That's the future" check in the move handler compares against the browser's clock, so with mismatched timezones it can still be off by a day right around midnight (independent of this bug, and much less visible). Can look at that separately if you want.