### PR TITLE
api: allow selecting the site with the X-Goatcounter-Site header

### DIFF
--- a/handlers/api_test.go
+++ b/handlers/api_test.go
@@ -976,3 +976,108 @@ func TestAPIStatsDetail(t *testing.T) {
 		})
 	}
 }
+
+// TestAPISiteSelect tests the X-Goatcounter-Site header of the API v0, which makes it
+// possible to query the stats of a specific (sub)site from behind a single
+// reverse proxy where the Host header always points at the same domain.
+func TestAPISiteSelect(t *testing.T) {
+	t.Run("select-subsite", func(t *testing.T) {
+		ctx := gctest.DB(t)
+		goatcounter.Config(ctx).GoatcounterCom = false
+
+		parent := Site(ctx)
+		sub := &goatcounter.Site{Code: "sub", Cname: new("sub.localhost"), Parent: &parent.ID}
+		if err := sub.Insert(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		// Host always points at the parent; X-Goatcounter-Site must select the subsite.
+		r, rr := newAPITest(ctx, t, "GET", "/api/v0/sites", nil, goatcounter.APIPermSiteRead)
+		r.Host = *parent.Cname
+		r.Header.Set("X-Goatcounter-Site", "sub.localhost")
+		newBackend(ctx).ServeHTTP(rr, r)
+		ztest.Code(t, rr, 200)
+
+		var resp struct {
+			Sites []goatcounter.Site `json:"sites"`
+		}
+		d := json.NewDecoder(rr.Body)
+		d.AllowReadonlyFields()
+		if err := d.Decode(&resp); err != nil {
+			t.Fatal(err)
+		}
+		if len(resp.Sites) == 0 || resp.Sites[0].ID != sub.ID {
+			t.Errorf("X-Goatcounter-Site did not select the subsite: got %+v, want first site id %d", resp.Sites, sub.ID)
+		}
+	})
+
+	t.Run("no-select-uses-host", func(t *testing.T) {
+		ctx := gctest.DB(t)
+		goatcounter.Config(ctx).GoatcounterCom = false
+
+		parent := Site(ctx)
+		sub := &goatcounter.Site{Code: "sub", Cname: new("sub.localhost"), Parent: &parent.ID}
+		if err := sub.Insert(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		r, rr := newAPITest(ctx, t, "GET", "/api/v0/sites", nil, goatcounter.APIPermSiteRead)
+		r.Host = *parent.Cname
+		newBackend(ctx).ServeHTTP(rr, r)
+		ztest.Code(t, rr, 200)
+
+		var resp struct {
+			Sites []goatcounter.Site `json:"sites"`
+		}
+		d := json.NewDecoder(rr.Body)
+		d.AllowReadonlyFields()
+		if err := d.Decode(&resp); err != nil {
+			t.Fatal(err)
+		}
+		if len(resp.Sites) == 0 || resp.Sites[0].ID != parent.ID {
+			t.Errorf("without the header the Host site should be used: got %+v, want first site id %d", resp.Sites, parent.ID)
+		}
+	})
+
+	t.Run("unknown-site", func(t *testing.T) {
+		ctx := gctest.DB(t)
+		goatcounter.Config(ctx).GoatcounterCom = false
+
+		r, rr := newAPITest(ctx, t, "GET", "/api/v0/sites", nil, goatcounter.APIPermSiteRead)
+		r.Host = *Site(ctx).Cname
+		r.Header.Set("X-Goatcounter-Site", "nope.localhost")
+		newBackend(ctx).ServeHTTP(rr, r)
+		ztest.Code(t, rr, 400)
+	})
+
+	t.Run("token-without-site-access", func(t *testing.T) {
+		ctx := gctest.DB(t)
+		goatcounter.Config(ctx).GoatcounterCom = false
+
+		parent := Site(ctx)
+		sub := &goatcounter.Site{Code: "sub", Cname: new("sub.localhost"), Parent: &parent.ID}
+		if err := sub.Insert(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		// A token scoped to the parent only (not to all sites) must not be able
+		// to read another site with the header.
+		tok := goatcounter.APIToken{
+			SiteID:      parent.ID,
+			UserID:      User(ctx).ID,
+			Name:        "parent-only",
+			Permissions: goatcounter.APIPermSiteRead,
+			Sites:       goatcounter.SiteIDs{parent.ID},
+		}
+		if err := tok.Insert(ctx); err != nil {
+			t.Fatal(err)
+		}
+
+		r, rr := newTest(ctx, "GET", "/api/v0/sites", nil)
+		r.Host = *parent.Cname
+		r.Header.Set("Authorization", "Bearer "+tok.Token)
+		r.Header.Set("X-Goatcounter-Site", "sub.localhost")
+		newBackend(ctx).ServeHTTP(rr, r)
+		ztest.Code(t, rr, 403)
+	})
+}

--- a/handlers/mw.go
+++ b/handlers/mw.go
@@ -173,46 +173,66 @@ func addctx(db zdb.DB, dev, saas, loadSite bool, dashTimeout int) func(http.Hand
 			// Load site from domain.
 			if loadSite {
 				var s goatcounter.Site
-				err := s.ByHost(ctx, r.Host)
 
-				// If there's just one site then we can just serve that; most
-				// people probably have just one site so it's all grand. Do
-				// print a warning in the console though.
-				if zdb.ErrNoRows(err) && !saas {
-					var sites goatcounter.Sites
-					err2 := sites.UnscopedList(ctx)
-					if err2 == nil && len(sites) == 1 {
-						s = sites[0]
-						err = nil
-
-						if r.URL.Path == "/" {
-							txt := fmt.Sprintf(""+
-								"Accessing the site on domain %q, but the configured domain is %q.\n\n"+
-								"This will work fine as long as you only have one site, but you *need* to use the "+
-								"configured domain if you add a second site so GoatCounter will know which site to use.",
-								znet.RemovePort(r.Host), *s.Cname)
-							if _, ok := slog.Default().Handler().(slog_align.AlignedHandler); ok {
-								txt = termtext.WordWrap(txt, 70, "")
-							} else {
-								txt = strings.ReplaceAll(txt, "\n\n", " ")
-							}
-							log.Warn(ctx, txt)
+				// The API v0 can select the site explicitly with the
+				// X-Goatcounter-Site header; this makes it possible to query
+				// the stats of any (sub)site of the same account from behind a
+				// single reverse proxy, where the Host header always points at
+				// the same domain. The site must still pass the regular API
+				// token check (which validates the token against the site's
+				// account).
+				if site := r.Header.Get("X-Goatcounter-Site"); site != "" && strings.HasPrefix(r.URL.Path, "/api/v0") {
+					err := s.Find(ctx, site)
+					if err != nil {
+						if zdb.ErrNoRows(err) {
+							err = guru.Errorf(400, "no site at this domain (%q)", site)
 						}
-					}
-					if err2 == nil && len(sites) == 0 {
-						noSites(db, w, r)
+						zhttp.ErrPage(w, r, err)
 						return
 					}
-				}
-				if err != nil {
-					if zdb.ErrNoRows(err) {
-						err = guru.Errorf(400, "no site at this domain (%q)", r.Host)
-					}
-					zhttp.ErrPage(w, r, err)
-					return
-				}
+					ctx = goatcounter.WithSite(ctx, &s)
+				} else {
+					err := s.ByHost(ctx, r.Host)
 
-				ctx = goatcounter.WithSite(ctx, &s)
+					// If there's just one site then we can just serve that; most
+					// people probably have just one site so it's all grand. Do
+					// print a warning in the console though.
+					if zdb.ErrNoRows(err) && !saas {
+						var sites goatcounter.Sites
+						err2 := sites.UnscopedList(ctx)
+						if err2 == nil && len(sites) == 1 {
+							s = sites[0]
+							err = nil
+
+							if r.URL.Path == "/" {
+								txt := fmt.Sprintf(""+
+									"Accessing the site on domain %q, but the configured domain is %q.\n\n"+
+									"This will work fine as long as you only have one site, but you *need* to use the "+
+									"configured domain if you add a second site so GoatCounter will know which site to use.",
+									znet.RemovePort(r.Host), *s.Cname)
+								if _, ok := slog.Default().Handler().(slog_align.AlignedHandler); ok {
+									txt = termtext.WordWrap(txt, 70, "")
+								} else {
+									txt = strings.ReplaceAll(txt, "\n\n", " ")
+								}
+								log.Warn(ctx, txt)
+							}
+						}
+						if err2 == nil && len(sites) == 0 {
+							noSites(db, w, r)
+							return
+						}
+					}
+					if err != nil {
+						if zdb.ErrNoRows(err) {
+							err = guru.Errorf(400, "no site at this domain (%q)", r.Host)
+						}
+						zhttp.ErrPage(w, r, err)
+						return
+					}
+
+					ctx = goatcounter.WithSite(ctx, &s)
+				}
 			}
 
 			// Make sure there's always a z18n object; will get overriden by
@@ -493,7 +513,7 @@ func addCORS() func(http.Handler) http.Handler {
 				w.Header().Add("Access-Control-Allow-Credentials", "true")
 				w.Header().Add("Access-Control-Allow-Origin", "*")
 				if r.Method == "OPTIONS" {
-					w.Header().Add("Access-Control-Allow-Headers", "Authorization, Content-Type")
+					w.Header().Add("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Goatcounter-Site")
 					w.Header().Add("Access-Control-Allow-Methods", "DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT")
 					w.Header().Add("Allow", "DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT")
 				}


### PR DESCRIPTION
The API v0 resolves the site from the Host header. That makes it impossible to query the stats of several sites from behind a single reverse proxy, because the Host always points at the same domain.

This adds an optional `X-Goatcounter-Site` header, only accepted for `/api/v0` requests. When present, the site is resolved by ID or domain (`Site.Find`) before the token check, instead of using the Host header.

Security is unchanged. The API token check still applies: the token must belong to the same account (site `IDOrParent`) and the site must be in the token's `Sites` list. A token scoped to one site cannot read another.

For example, with several subsites of the same account behind a reverse proxy that forwards a fixed Host:

```
curl -H "X-Goatcounter-Site: subsite" \
     -H "Authorization: Bearer <token>" \
     https://stats.example.com/api/v0/stats
```

Tests: `TestAPISiteSelect` in `handlers/api_test.go` covers four cases: selecting a subsite, falling back to Host when the header is absent, unknown site returning 400, and a token without access to the site returning 403.
